### PR TITLE
ci: title the promotion pull request as a release

### DIFF
--- a/.github/workflows/dev-to-main-pr.yml
+++ b/.github/workflows/dev-to-main-pr.yml
@@ -31,7 +31,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_TITLE: "merge: promote dev to main"
+          # The title has to read as a release, not as a routine merge: merging
+          # this is what ships production and publishes the signed release.
+          PR_TITLE: "release: promote dev to production"
           PR_BODY: |
             Merging this pull request deploys production to `CLOUDFLARE_PAGES_PROJECT` and publishes the signed prerelease via `.github/workflows/github-release.yml`.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -211,7 +211,7 @@ GitHub の Cloudflare Git Integration とは二重運用しません。GitHub Ac
 * `main` への `push` では追加で `.github/workflows/github-release.yml` が署名付き
   prerelease を発行する
 
-`.github/workflows/dev-to-main-pr.yml` は `dev` への push、または意図的な `workflow_dispatch` で、対応する open PR がなく、`dev` が `main` より先行するコミットを持ち、`main` に `dev` のコミットツリーがまだない場合に `dev` → `main` 昇格 PR を開く。マージも push もしない。
+`.github/workflows/dev-to-main-pr.yml` は `dev` への push、または意図的な `workflow_dispatch` で、対応する open PR がなく、`dev` が `main` より先行するコミットを持ち、`main` に `dev` のコミットツリーがまだない場合に `release: promote dev to production` という PR を開く。マージも push もしない。マージが本番デプロイと署名付きリリースの発行そのものであるため、タイトルは merge ではなく release と表現する。
 
 * この PR をマージせずに閉じるのは永久的な拒否ではなく一時停止である。次の `dev` push は新しい情報なので新しい PR を開く。`workflow_dispatch` も人が意図して行う操作であり、人による拒否と競合しない
 * これは `main` の ruleset が `validate` と `e2e` を strict up-to-date で必須にしている間だけ実効性のある本番ゲートである。必須チェックを削除すると、チェックに失敗した dev push であっても本番昇格を誰でもマージできる

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ request targeting `main` or `dev`:
 * A `push` to `main` additionally publishes a signed prerelease via
   `.github/workflows/github-release.yml`
 
-`.github/workflows/dev-to-main-pr.yml` opens a `dev` → `main` promotion pull request on a `dev` push, or on an intentional `workflow_dispatch`, when no matching open PR exists, `dev` has commits ahead of `main`, and `main` does not already have `dev`'s commit tree. It never merges or pushes.
+`.github/workflows/dev-to-main-pr.yml` opens the pull request titled `release: promote dev to production` on a `dev` push, or on an intentional `workflow_dispatch`, when no matching open PR exists, `dev` has commits ahead of `main`, and `main` does not already have `dev`'s commit tree. It never merges or pushes. The title says release rather than merge because merging it is what deploys production and publishes the signed release.
 
 * Closing this PR without merging is a pause, not a permanent veto: the next push to `dev` opens a new one because a new dev commit is new information; `workflow_dispatch` also opens one as a deliberate human action, so it cannot conflict with a human veto
 * This is a real production gate only while `main`'s ruleset requires `validate` and `e2e` with strict up-to-date status checks. If those required checks are removed, even a red dev push becomes an openly mergeable production promotion


### PR DESCRIPTION
`merge: promote dev to main` described the git operation, not the consequence. Merging that pull request deploys production to `CLOUDFLARE_PAGES_PROJECT` and publishes the signed prerelease via `github-release.yml`, so the title should say so.

- `PR_TITLE` in `.github/workflows/dev-to-main-pr.yml` becomes `release: promote dev to production`, with a comment recording why.
- Both READMEs now name the title, so a reader can recognise the pull request, and state the reason for the wording.

The already-open promotion pull request (#6) is retitled separately with `gh pr edit`, since the workflow leaves an existing open PR alone by design.

Verified: `actionlint` clean over all three workflows. No source, test or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)