### PR TITLE
fix(qr): acquire the camera before awaiting the decoder WASM

### DIFF
--- a/src/qr/decode.ts
+++ b/src/qr/decode.ts
@@ -60,7 +60,7 @@ const zxingReaderOptions: ReaderOptions = {
   tryDownscale: true,
 }
 
-let zxingModulePromise: Promise<unknown> | undefined
+let zxingModulePromise: Promise<void> | undefined
 
 interface ScannerControls {
   stop(): void
@@ -113,31 +113,37 @@ let activeAttempt: CameraAttempt | null = null
 // an unresolved request.
 let cameraAcquisitionQueue: Promise<void> = Promise.resolve()
 
-async function prepareSharedZXingModule(): Promise<void> {
-  let modulePromise = zxingModulePromise
-  if (modulePromise === undefined) {
-    try {
-      modulePromise = prepareZXingModule({
-        overrides: zxingModuleOverrides,
-        fireImmediately: true,
-      })
-      zxingModulePromise = modulePromise
-    } catch (error) {
-      zxingModulePromise = undefined
-      purgeZXingModule()
-      throw error
-    }
+// Start (or reuse) WASM preparation WITHOUT awaiting it. iOS Safari only opens the
+// camera permission prompt while the user activation from the tap is still live, and
+// fetching plus compiling a one-megabyte binary outlives that window. Acquisition must
+// therefore reach getUserMedia first; the decoder awaits this promise later, after the
+// first frame has been drawn.
+function beginZXingModulePreparation(): Promise<void> {
+  const existing = zxingModulePromise
+  if (existing !== undefined) return existing
+
+  let started: Promise<unknown>
+  try {
+    started = prepareZXingModule({
+      overrides: zxingModuleOverrides,
+      fireImmediately: true,
+    })
+  } catch (error) {
+    purgeZXingModule()
+    return Promise.reject(error instanceof Error ? error : new Error(String(error)))
   }
 
-  try {
-    await modulePromise
-  } catch (error) {
-    if (zxingModulePromise === modulePromise) {
+  const preparation = started.then(() => undefined)
+  zxingModulePromise = preparation
+  // Reset on failure so the restart button can retry, and swallow the rejection here:
+  // an attempt can stop before any decode awaits this promise.
+  void preparation.catch(() => {
+    if (zxingModulePromise === preparation) {
       zxingModulePromise = undefined
       purgeZXingModule()
     }
-    throw error
-  }
+  })
+  return preparation
 }
 
 // true does not automatically restart; it directs the UI to transition to stopped
@@ -396,6 +402,7 @@ async function startAttempt(
   handle: QrScanHandle,
   onText: (text: string) => void,
   once: boolean,
+  modulePreparation: Promise<void>,
 ): Promise<ScannerControls> {
   const stream = await acquireWithRetries(attempt)
   if (!isActiveAttempt(attempt)) {
@@ -633,6 +640,12 @@ async function startAttempt(
       )
       if (!isActiveAttempt(attempt)) return
 
+      // The decoder module is awaited here, not before acquisition: the watchdog is
+      // already cleared by the successful draw above, so a cold instantiate cannot be
+      // mistaken for a stalled camera.
+      await modulePreparation
+      if (!isActiveAttempt(attempt)) return
+
       decodeStartedAt = Date.now()
       lastDecodeStartedAt = decodeStartedAt
       const results = await readBarcodes(imageData, zxingReaderOptions)
@@ -748,30 +761,19 @@ async function startQrScanImplementation(
   if (!isActiveAttempt(attempt)) {
     throw attempt.failure ?? new ConcreteAppError("CAMERA_NOT_AVAILABLE")
   }
-  try {
-    await prepareSharedZXingModule()
-  } catch (error) {
-    if (!isActiveAttempt(attempt)) {
-      throw attempt.failure ?? new ConcreteAppError("CAMERA_NOT_AVAILABLE")
-    }
-    const mapped = new ConcreteAppError("CAMERA_NOT_AVAILABLE")
-    reportAttemptError(
-      attempt,
-      mapped,
-      cameraDiagnostic(attempt, diagnosticName(error)),
-    )
-    stopAttempt(attempt)
-    throw mapped
-  }
-  if (!isActiveAttempt(attempt)) {
-    throw attempt.failure ?? new ConcreteAppError("CAMERA_NOT_AVAILABLE")
-  }
+
+  // Not awaited: getUserMedia has to run inside the tap's user-activation window or
+  // iOS Safari never shows the permission prompt. The decoder awaits this after its
+  // first drawn frame instead, and a preparation failure surfaces there as
+  // CAMERA_NOT_AVAILABLE.
+  const modulePreparation = beginZXingModulePreparation()
 
   const operation: Promise<AttemptOutcome> = startAttempt(
     attempt,
     handle,
     onText,
     options?.once ?? true,
+    modulePreparation,
   ).then(
     (controls) => ({ kind: "ready", controls }),
     (error: unknown) => ({ kind: "error", error }),

--- a/tests/unit/qr-scanner.test.ts
+++ b/tests/unit/qr-scanner.test.ts
@@ -863,30 +863,150 @@ describe("camera scanner lifecycle", () => {
     },
   )
 
-  it("surfaces WASM preparation failure before acquisition or loop startup", async () => {
+  it("acquires the camera before awaiting a never-settling WASM preparation", async () => {
+    const preparation = deferred<unknown>()
+    const track = new FakeTrack()
+    zxing.prepareZXingModule.mockReturnValueOnce(preparation.promise)
+    getUserMedia.mockResolvedValue(mediaStream(track))
+    const fakeVideo = new FakeVideo()
+    const decoder = await loadDecoder()
+
+    const scanPromise = decoder.startQrScan(
+      asVideoElement(fakeVideo),
+      vi.fn(),
+      vi.fn(),
+      { once: false },
+    )
+
+    expect(zxing.prepareZXingModule).toHaveBeenCalledOnce()
+    await flushMicrotasks()
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    expect(zxing.prepareZXingModule.mock.invocationCallOrder[0]).toBeLessThan(
+      getUserMedia.mock.invocationCallOrder[0]!,
+    )
+
+    const handle = await scanPromise
+    expect(fakeVideo.play).toHaveBeenCalledOnce()
+    expect(zxing.readBarcodes).not.toHaveBeenCalled()
+
+    handle.stop()
+    expect(track.stop).toHaveBeenCalledOnce()
+  })
+
+  it("surfaces WASM preparation failure after acquisition and stops the track", async () => {
     const preparationError = new WebAssembly.CompileError("bad reader module")
     zxing.prepareZXingModule.mockRejectedValueOnce(preparationError)
+    const track = new FakeTrack()
+    getUserMedia.mockResolvedValue(mediaStream(track))
     const onError = vi.fn()
     const fakeVideo = new FakeVideo()
     const decoder = await loadDecoder()
 
-    await expect(
-      decoder.startQrScan(asVideoElement(fakeVideo), vi.fn(), onError),
-    ).rejects.toMatchObject({ code: "CAMERA_NOT_AVAILABLE" })
+    const handle = await decoder.startQrScan(
+      asVideoElement(fakeVideo),
+      vi.fn(),
+      onError,
+      { once: false },
+    )
+    await advance(0)
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
       {
-        phase: "acquiring",
+        phase: "playing",
         name: "CompileError",
-        detail: "640x480 rs=2 track=none",
+        detail: "640x480 rs=2 track=live/unmuted",
       },
     )
     expect(zxing.purgeZXingModule).toHaveBeenCalledOnce()
-    expect(getUserMedia).not.toHaveBeenCalled()
-    expect(fakeVideo.play).not.toHaveBeenCalled()
-    expect(createElement).not.toHaveBeenCalled()
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    expect(fakeVideo.play).toHaveBeenCalledOnce()
+    expect(canvases[0]!.drawImage).toHaveBeenCalledOnce()
     expect(zxing.readBarcodes).not.toHaveBeenCalled()
+    expect(track.stop).toHaveBeenCalledOnce()
+    expect(track.readyState).toBe("ended")
+    expect(fakeVideo.srcObject).toBeNull()
+    expect(vi.getTimerCount()).toBe(0)
+
+    handle.stop()
+    expect(track.stop).toHaveBeenCalledOnce()
+  })
+
+  it("handles a preparation rejection after stop without an unhandled rejection", async () => {
+    vi.useRealTimers()
+    const preparation = deferred<unknown>()
+    const preparationError = new WebAssembly.CompileError("late bad reader module")
+    const track = new FakeTrack()
+    zxing.prepareZXingModule.mockReturnValueOnce(preparation.promise)
+    getUserMedia.mockResolvedValue(mediaStream(track))
+    const onError = vi.fn()
+    const decoder = await loadDecoder()
+    const handle = await decoder.startQrScan(
+      videoElement(),
+      vi.fn(),
+      onError,
+      { once: false },
+    )
+
+    handle.stop()
+    const unhandledRejections: unknown[] = []
+    const recordUnhandled = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on("unhandledRejection", recordUnhandled)
+    try {
+      preparation.reject(preparationError)
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0)
+      })
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off("unhandledRejection", recordUnhandled)
+    }
+
+    expect(zxing.purgeZXingModule).toHaveBeenCalledOnce()
+    expect(onError).not.toHaveBeenCalled()
+    expect(zxing.readBarcodes).not.toHaveBeenCalled()
+    expect(track.stop).toHaveBeenCalledOnce()
+  })
+
+  it("waits for slow WASM preparation only after drawing the first frame", async () => {
+    const preparation = deferred<unknown>()
+    const track = new FakeTrack()
+    zxing.prepareZXingModule.mockReturnValueOnce(preparation.promise)
+    getUserMedia.mockResolvedValue(mediaStream(track))
+    zxing.readBarcodes.mockResolvedValueOnce(barcode("OCK1:slow-module"))
+    const onText = vi.fn()
+    const onError = vi.fn()
+    const decoder = await loadDecoder()
+    const handle = await decoder.startQrScan(
+      videoElement(),
+      onText,
+      onError,
+    )
+
+    await advance(0)
+
+    const canvas = canvases[0]!
+    expect(canvas.drawImage).toHaveBeenCalledOnce()
+    expect(canvas.getImageData).toHaveBeenCalledOnce()
+    expect(zxing.readBarcodes).not.toHaveBeenCalled()
+    expect(onText).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+    expect(track.stop).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+
+    preparation.resolve({})
+    await flushMicrotasks()
+
+    expect(zxing.readBarcodes).toHaveBeenCalledOnce()
+    expect(canvas.drawImage.mock.invocationCallOrder[0]).toBeLessThan(
+      zxing.readBarcodes.mock.invocationCallOrder[0]!,
+    )
+    expect(onText).toHaveBeenCalledWith("OCK1:slow-module")
+    expect(onError).not.toHaveBeenCalled()
+    expect(track.stop).toHaveBeenCalledOnce()
+    handle.stop()
   })
 
   it("retries a transient acquisition failure and then starts", async () => {


### PR DESCRIPTION
## Symptom

On iPhone the camera permission prompt stopped appearing after the zxing-wasm swap (#14), so scanning could not start at all.

## Cause

`startQrScan` awaited `prepareZXingModule` before reaching `getUserMedia`. iOS Safari only opens the permission prompt while the user activation from the tap is still live, and fetching plus compiling the ~1MB reader binary outlives that window. `src/qr/decode.ts` called the module await at the top of `startQrScanImplementation`, with acquisition several awaits downstream.

## Fix

Preparation starts **without** being awaited, acquisition runs immediately inside the activation window, and the decoder awaits the module in the decode path — placed **after** the first successful `drawImage`, so the frame-readiness watchdog is already cleared and a cold instantiate cannot be mistaken for a stalled camera.

Preserved: a preparation failure still surfaces as `CAMERA_NOT_AVAILABLE`, stops the attempt and leaves no live track; the shared promise still resets (and purges) so the restart button can retry; a rejection nothing awaits no longer escapes as an unhandled rejection.

The unit case `surfaces WASM preparation failure before acquisition or loop startup` pinned the buggy ordering, so it was rewritten around the new contract rather than deleted. Four cases now cover it: acquisition proceeds while preparation never settles (with explicit call ordering), failure surfaces after acquisition, no unhandled rejection when the attempt stops first, and a slow preparation that resolves after the first draw still decodes.

## Verification

| command | result |
|---|---|
| `aube run typecheck` | pass |
| `aube run lint` | 0 errors (16 pre-existing warnings) |
| `aube run test` | 48 files, 549 tests passed (`qr-scanner` 32) |
| `aube run build:prod` | pass |
| `aube run test:e2e` | 22 passed |

Not verifiable in CI: the actual iOS permission prompt. That is what this needs on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)