### PR TITLE
chore: route agent entry through CLAUDE.local and ignore herdrpowers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@ coverage/
 !.claude/skills/nation-state-security/
 
 # Local task workflow (untracked)
-/WORKFLOW.md
+/CLAUDE.local.md
+
+# herdrpowers repo config and pane workspace (local only)
+.herdrpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-@WORKFLOW.md
+@CLAUDE.local.md
 
 # Project Goal
 


### PR DESCRIPTION
## Summary
- Point `CLAUDE.md` at `@CLAUDE.local.md` instead of `@WORKFLOW.md`
- Ignore `/CLAUDE.local.md` and `.herdrpowers/` so local agent/herdr config stays out of the repo

## Test plan
- [ ] Confirm `CLAUDE.md` still loads local instructions via `@CLAUDE.local.md`
- [ ] Confirm `.herdrpowers/` and `CLAUDE.local.md` are not tracked (`git check-ignore -v` / `git status`)
- [ ] No unintended ignore changes for other paths


Made with [Cursor](https://cursor.com)