### PR TITLE
chore(make): name the repo's check commands as make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+# Verification and local-preview targets. Every node execution goes through
+# `aube run <script>` — npm is forbidden in this repo.
+#
+# The check targets are the commands declared in CLAUDE.local.md's
+# `Herdrpowers Configuration`; keep the two in step when either changes.
+
+.DEFAULT_GOAL := check
+
+# BASELINE_VERIFICATION_COMMAND
+.PHONY: check
+check:
+	aube run typecheck
+	aube run lint
+	aube run test
+
+# FULL_TEST_SUITE_COMMAND
+.PHONY: test-all
+test-all:
+	aube run test
+	aube run test:e2e
+
+# TARGETED_TEST_COMMAND: make test-one FILE=tests/ui/keys-settings.test.tsx
+.PHONY: test-one
+test-one:
+	@test -n '$(FILE)' || { echo 'usage: make test-one FILE=tests/ui/keys-settings.test.tsx'; exit 1; }
+	aube run test -- $(FILE)
+
+# What a UI change owes: baseline plus the e2e suite.
+.PHONY: check-ui
+check-ui: check e2e
+
+# SUPPLEMENTAL_VERIFICATION_COMMANDS — run the ones the change actually touches.
+.PHONY: e2e
+e2e: # UI changes
+	aube run test:e2e
+
+.PHONY: build
+build: # vite / env changes
+	aube run build
+
+.PHONY: build-prod
+build-prod: # .env.prod changes
+	aube run build:prod
+
+# Narrow subsets for fast feedback during protocol work; `check` covers them too.
+.PHONY: pq
+pq:
+	aube run test:pq
+	aube run test:pq-vectors
+	aube run test:qr-multipart
+
+# The pair playwright.config.ts boots for e2e: the production bundle behind the
+# header-aware static server, so `_headers` / `_redirects` behave as the deployed
+# origin does. Serves on :4173 until interrupted.
+.PHONY: serve-prod
+serve-prod:
+	aube run build:prod
+	aube run serve:dist
+
+# Vite dev server on this checkout (hot reload); the served preview at
+# qr-crypt.local is a different thing — see fresh-local below.
+.PHONY: dev
+dev:
+	aube run dev
+
+# Refresh the preview worktree that caddy-server serves at qr-crypt.local
+# (see /mnt/ssd1/repos/caddy-server/sites.yaml: working_dir .worktrees/local,
+# build_command `aube run build`). Detached checkout, so REF may be checked out
+# in another worktree at the same time.
+#
+#   make fresh-local                                  # origin/dev
+#   make fresh-local REF=feat/scanner-and-decrypt-icons
+
+REF ?= dev
+LOCAL := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/.worktrees/local
+
+.PHONY: fresh-local
+fresh-local:
+	@test -z "$$(git -C '$(LOCAL)' status --porcelain --untracked-files=no)" \
+		|| { echo 'refusing: $(LOCAL) has uncommitted changes - commit or discard them first'; exit 1; }
+	git fetch origin $(REF)
+	git -C '$(LOCAL)' checkout --detach origin/$(REF)
+	cd '$(LOCAL)' && aube run build

--- a/Makefile
+++ b/Makefile
@@ -68,16 +68,19 @@ dev:
 # build_command `aube run build`). Detached checkout, so REF may be checked out
 # in another worktree at the same time.
 #
-#   make fresh-local                                  # origin/dev
+#   make fresh-local                                  # branch name, dev by default
 #   make fresh-local REF=feat/scanner-and-decrypt-icons
 
 REF ?= dev
+# `REF=origin/dev` names the same branch as `REF=dev`; make's trailing-comment
+# whitespace would end up inside the value, so keep this note off the line.
+BRANCH := $(patsubst origin/%,%,$(REF))
 LOCAL := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/.worktrees/local
 
 .PHONY: fresh-local
 fresh-local:
 	@test -z "$$(git -C '$(LOCAL)' status --porcelain --untracked-files=no)" \
 		|| { echo 'refusing: $(LOCAL) has uncommitted changes - commit or discard them first'; exit 1; }
-	git fetch origin $(REF)
-	git -C '$(LOCAL)' checkout --detach origin/$(REF)
+	git fetch origin $(BRANCH)
+	git -C '$(LOCAL)' checkout --detach origin/$(BRANCH)
 	cd '$(LOCAL)' && aube run build


### PR DESCRIPTION
## What

One new file, `Makefile`. No source change, no dependency, nothing runs differently in CI — it only gives the commands this repo already runs a callable name.

| Target | Runs | Why it exists |
| --- | --- | --- |
| `check` (default goal) | `typecheck` → `lint` → `test` | the baseline every task owes |
| `check-ui` | `check` + `e2e` | what a UI change owes, per the repo's supplemental rule |
| `test-all` | `test` + `test:e2e` | the full suite |
| `test-one FILE=…` | `aube run test -- $(FILE)` | targeted run; refuses without `FILE` |
| `e2e` / `build` / `build-prod` | the matching script | supplemental, picked by touched surface |
| `pq` | `test:pq` + `test:pq-vectors` + `test:qr-multipart` | the three protocol subsets, already treated as one group |
| `serve-prod` | `build:prod` + `serve:dist` | the exact pair `playwright.config.ts:11` boots — production bundle behind the header-aware server on :4173, so `_headers` / `_redirects` behave as the deployed origin does |
| `dev` | `aube run dev` | vite dev server on this checkout |
| `fresh-local [REF=…]` | fetch → detached checkout → `aube run build` | re-points the preview worktree caddy-server serves at qr-crypt.local |

Every recipe goes through `aube run` — npm stays forbidden.

Two deliberate choices in `fresh-local`: it checks out **detached**, so `REF` may be checked out in another worktree at the same time; and it **refuses** while `.worktrees/local` has uncommitted changes rather than resetting over them, because that worktree is retained infrastructure, not scratch.

No target for the one-word scripts (`aube run test:pq` on its own, `bench:pq`) — an alias that saves no typing is just a second place to keep in step.

## Verification

- `make check` — exit 0 (typecheck clean, lint 0 errors / 48 pre-existing warnings, 634 tests passed)
- `make test-one FILE=tests/ui/keys-settings.test.tsx` — 15 passed; bare `make test-one` exits 1 with usage
- `make pq` — exit 0 (132 + 12 + 86 passed)
- `make build-prod` — exit 0; `serve:dist` answers `HTTP 200` on :4173
- `make fresh-local` — refuses as designed while `.worktrees/local` is dirty
- `make -n` on the rest

The local agent instructions (`CLAUDE.local.md`, gitignored) now name these targets as the repo's verification commands, so that file and this Makefile need to move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)