### PR TITLE
chore: drop the on-screen scanner diagnostics and their plumbing

### DIFF
--- a/src/components/qr-scanner-panel.tsx
+++ b/src/components/qr-scanner-panel.tsx
@@ -12,8 +12,7 @@ import { formatFramePositions } from "@/features/presentation"
 import { useQrReaderReadiness } from "@/hooks/use-qr-reader-readiness"
 import {
   startQrScan,
-  type CameraDiagnostic,
-  type CameraPipelineDiagnostic,
+  type CameraFailureState,
   type CameraScanState,
   type QrScanHandle,
 } from "@/qr/decode"
@@ -99,9 +98,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
   )
   const localizedError =
     error === null ? null : t(error.key, error.values)
-  const [diagnostic, setDiagnostic] = useState<CameraDiagnostic | null>(null)
-  const [pipelineDiagnostic, setPipelineDiagnostic] =
-    useState<CameraPipelineDiagnostic | null>(null)
   const [integrityConfirmed, setIntegrityConfirmed] = useState(
     transferState.kind === "complete",
   )
@@ -213,8 +209,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
       cancelRun(run, "idle")
       publishCameraMode("delivering")
       setError(null)
-      setDiagnostic(null)
-      setPipelineDiagnostic(null)
       setCameraStatus(localized("scanner.status.delivering"))
       void (async () => {
         try {
@@ -254,8 +248,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
       cameraStateRef.current = "failed"
       publishCameraMode("stopped")
       setError(localized("scanner.error.videoNotReady"))
-      setDiagnostic(null)
-      setPipelineDiagnostic(null)
       setCameraStatus(localized("scanner.status.videoNotReady"))
       return
     }
@@ -265,8 +257,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
     cameraStateRef.current = "acquiring"
     publishCameraMode("running")
     setError(null)
-    setDiagnostic(null)
-    setPipelineDiagnostic(null)
     setCameraStatus(localized("scanner.status.preparing"))
 
     const finishSingleScan = (target: ScannerTarget, payload: string) => {
@@ -392,30 +382,14 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
 
     const onCameraError = (
       scanError: AppError,
-      cameraDiagnostic: CameraDiagnostic,
+      failedState: CameraFailureState,
     ) => {
       if (run.cancelled || activeRunRef.current !== run) return
       run.errorReported = true
-      const failedState: CameraScanState =
-        cameraDiagnostic.phase === "track-ended" ? "track-ended" : "failed"
       cancelRun(run, failedState)
       publishCameraMode("stopped")
       setError(localizedErrorCode(scanError.code))
-      setDiagnostic(
-        scanError.code === "CAMERA_PERMISSION_DENIED" ||
-          scanError.code === "CAMERA_NOT_AVAILABLE" ||
-          scanError.code === "QR_DECODE_PROGRESS_TIMEOUT"
-          ? cameraDiagnostic
-          : null,
-      )
       setCameraStatus(localized("scanner.status.cameraError"))
-    }
-
-    const onPipelineDiagnostic = (
-      nextDiagnostic: CameraPipelineDiagnostic,
-    ) => {
-      if (run.cancelled || activeRunRef.current !== run) return
-      setPipelineDiagnostic(nextDiagnostic)
     }
 
     let startPromise: Promise<QrScanHandle>
@@ -425,7 +399,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
       startPromise = startQrScan(video, onText, onCameraError, {
         once: false,
         signal: run.abortController.signal,
-        onDiagnostic: onPipelineDiagnostic,
       })
     } catch (caught) {
       const appError = deliveryError(caught)
@@ -433,8 +406,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
       cancelRun(run, "failed")
       publishCameraMode("stopped")
       setError(localizedErrorCode(appError.code))
-      setDiagnostic(null)
-      setPipelineDiagnostic(null)
       setCameraStatus(localized("scanner.status.startFailed"))
       return
     }
@@ -473,8 +444,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
         cancelRun(run, "failed")
         publishCameraMode("stopped")
         setError(localizedErrorCode(appError.code))
-        setDiagnostic(null)
-        setPipelineDiagnostic(null)
         setCameraStatus(localized("scanner.status.startFailed"))
       })
   }, [
@@ -491,8 +460,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
     cancelRun(run, "idle")
     publishCameraMode("stopped")
     setError(localized("scanner.error.stopped"))
-    setDiagnostic(null)
-    setPipelineDiagnostic(null)
     setCameraStatus(localized("scanner.status.stopped"))
   }, [cancelRun, publishCameraMode])
 
@@ -506,8 +473,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
     publishCameraMode("idle")
     setIntegrityConfirmed(false)
     setError(null)
-    setDiagnostic(null)
-    setPipelineDiagnostic(null)
     setCameraStatus(localized("scanner.status.discardedCanStart"))
   }, [cancelRun, publishCameraMode, publishTransferState])
 
@@ -533,8 +498,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
         cancelRun(run, "track-ended")
         publishCameraMode("stopped")
         setError(localized("scanner.error.hiddenStopped"))
-        setDiagnostic(null)
-        setPipelineDiagnostic(null)
         setCameraStatus(localized("scanner.status.leftScreenStopped"))
         return
       }
@@ -559,8 +522,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
     cancelRun(activeRunRef.current, "failed")
     publishCameraMode("stopped")
     setError(localized("scanner.error.cameraUnavailable"))
-    setDiagnostic(null)
-    setPipelineDiagnostic(null)
     setCameraStatus(localized("scanner.status.cameraUnavailable"))
   }, [cameraAvailable, cancelRun, publishCameraMode])
 
@@ -578,8 +539,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
     setError(
       next.kind === "error" ? localizedErrorCode(next.code) : null,
     )
-    setDiagnostic(null)
-    setPipelineDiagnostic(null)
     setCameraStatus(localized("scanner.status.idlePrompt"))
   }, [
     cancelRun,
@@ -604,8 +563,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
       if (run !== null) cancelRun(run, "idle")
       publishCameraMode("idle")
       setIntegrityConfirmed(false)
-      setDiagnostic(null)
-      setPipelineDiagnostic(null)
       setError(
         previousKind === "collecting"
           ? localized("scanner.error.expiredDiscarded")
@@ -777,34 +734,6 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
             <AlertTitle>{t("scanner.error.title")}</AlertTitle>
             <AlertDescription>{localizedError}</AlertDescription>
           </Alert>
-        )}
-        {diagnostic && (
-          <p
-            aria-label={t("scanner.diagnostic.ariaLabel")}
-            className="font-mono text-xs text-muted-foreground"
-          >
-            {t("scanner.diagnostic", {
-              name: diagnostic.name ?? "unknown",
-              phase: diagnostic.phase,
-              detail: diagnostic.detail,
-            })}
-          </p>
-        )}
-        {pipelineDiagnostic && (
-          <p
-            aria-label={t("scanner.pipelineDiagnostic.ariaLabel")}
-            className="font-mono text-[11px] leading-relaxed text-muted-foreground"
-          >
-            {t("scanner.pipelineDiagnostic", {
-              moduleState: pipelineDiagnostic.readerModuleState,
-              frames: pipelineDiagnostic.videoFramesDrawn,
-              attempts: pipelineDiagnostic.decodeAttemptsCompleted,
-              results: pipelineDiagnostic.decodeResultsSeen,
-              lastError:
-                pipelineDiagnostic.lastErrorName ??
-                t("scanner.pipelineDiagnostic.noError"),
-            })}
-          </p>
         )}
 
         {multipart !== undefined ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -542,12 +542,6 @@ const en = {
   "scanner.sha256Notice":
     "SHA-256 detects missing or mixed frames during transfer; it does not prove the sender's authenticity.",
   "scanner.error.title": "The scan could not be completed",
-  "scanner.diagnostic.ariaLabel": "Camera diagnostic",
-  "scanner.diagnostic": "Diagnostic: {name} @{phase} [{detail}]",
-  "scanner.pipelineDiagnostic.ariaLabel": "QR decode pipeline diagnostic",
-  "scanner.pipelineDiagnostic":
-    "Pipeline: module={moduleState} frames={frames} attempts={attempts} results={results} last={lastError}",
-  "scanner.pipelineDiagnostic.noError": "none",
   "scanner.button.discard": "Discard scan state",
   "scanner.button.stopCamera": "Stop camera",
   "scanner.closed.multipartProgress":
@@ -1210,12 +1204,6 @@ const ja = {
   "scanner.sha256Notice":
     "SHA-256は転送中の欠損・混在検出用であり、送信者の真正性を証明しません。",
   "scanner.error.title": "読み取りを完了できません",
-  "scanner.diagnostic.ariaLabel": "カメラ診断",
-  "scanner.diagnostic": "診断: {name} @{phase} [{detail}]",
-  "scanner.pipelineDiagnostic.ariaLabel": "QR復号パイプライン診断",
-  "scanner.pipelineDiagnostic":
-    "パイプライン: module={moduleState} frames={frames} attempts={attempts} results={results} last={lastError}",
-  "scanner.pipelineDiagnostic.noError": "なし",
   "scanner.button.discard": "読取状態を破棄",
   "scanner.button.stopCamera": "カメラを停止",
   "scanner.closed.multipartProgress":

--- a/src/qr/camera/acquire.ts
+++ b/src/qr/camera/acquire.ts
@@ -3,15 +3,11 @@ import {
   clearAttempt,
   isActiveAttempt,
 } from "@/qr/camera/attempt-registry"
-import {
-  cameraDiagnostic,
-  isTransientCameraAcquireError,
-  publishPipelineDiagnostic,
-} from "@/qr/camera/diagnostics"
+import { isTransientCameraAcquireError } from "@/qr/camera/diagnostics"
 import { AttemptCancelled } from "@/qr/camera/types"
 import type {
   CameraAttempt,
-  CameraDiagnostic,
+  CameraFailureState,
   ScannerControls,
 } from "@/qr/camera/types"
 
@@ -85,14 +81,12 @@ export function stopAttempt(attempt: CameraAttempt): void {
 export function reportAttemptError(
   attempt: CameraAttempt,
   error: ConcreteAppError,
-  diagnostic: CameraDiagnostic,
+  failureState: CameraFailureState = "failed",
 ): void {
   if (!isActiveAttempt(attempt) || attempt.errorReported) return
   attempt.errorReported = true
   attempt.failure = error
-  if (diagnostic.name !== null) attempt.lastErrorName = diagnostic.name
-  publishPipelineDiagnostic(attempt)
-  attempt.onError(error, diagnostic)
+  attempt.onError(error, failureState)
 }
 
 function acquireCamera(attempt: CameraAttempt): Promise<MediaStream> {
@@ -131,9 +125,8 @@ export function watchTrackEnds(
 ): void {
   const onEnded: EventListener = () => {
     if (!isActiveAttempt(attempt)) return
-    attempt.phase = "track-ended"
     const error = new ConcreteAppError("CAMERA_NOT_AVAILABLE")
-    reportAttemptError(attempt, error, cameraDiagnostic(attempt, null, "track-ended"))
+    reportAttemptError(attempt, error, "track-ended")
     stopAttempt(attempt)
   }
 
@@ -181,7 +174,6 @@ export async function acquireWithRetries(
   let retries = 0
   while (true) {
     if (!isActiveAttempt(attempt)) throw new AttemptCancelled()
-    attempt.phase = "acquiring"
     try {
       return await acquireCamera(attempt)
     } catch (error) {

--- a/src/qr/camera/diagnostics.ts
+++ b/src/qr/camera/diagnostics.ts
@@ -2,7 +2,7 @@ import { AppError as ConcreteAppError } from "@/crypto/errors"
 import type { CameraAttempt } from "@/qr/camera/types"
 
 const CAMERA_DIAGNOSTIC_NAME = /^[A-Za-z]{1,40}$/
-export function diagnosticName(error: unknown): string {
+function diagnosticName(error: unknown): string {
   if (typeof error !== "object" || error === null || !("name" in error)) {
     return "unknown"
   }

--- a/src/qr/camera/diagnostics.ts
+++ b/src/qr/camera/diagnostics.ts
@@ -1,12 +1,5 @@
 import { AppError as ConcreteAppError } from "@/crypto/errors"
-import { isActiveAttempt } from "@/qr/camera/attempt-registry"
-import type {
-  CameraAttempt,
-  CameraDiagnostic,
-  CameraDiagnosticPhase,
-  CameraPipelineDiagnostic,
-  ReaderModuleState,
-} from "@/qr/camera/types"
+import type { CameraAttempt } from "@/qr/camera/types"
 
 const CAMERA_DIAGNOSTIC_NAME = /^[A-Za-z]{1,40}$/
 export function diagnosticName(error: unknown): string {
@@ -30,61 +23,6 @@ export function cameraTrack(attempt: CameraAttempt): MediaStreamTrack | undefine
 
 export function videoDimension(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0
-}
-
-function diagnosticDetail(attempt: CameraAttempt): string {
-  const track = cameraTrack(attempt)
-  const trackDetail =
-    track === undefined
-      ? "none"
-      : `${track.readyState}/${track.muted ? "muted" : "unmuted"}`
-  return `${videoDimension(attempt.video.videoWidth)}x${videoDimension(
-    attempt.video.videoHeight,
-  )} rs=${videoDimension(attempt.video.readyState)} track=${trackDetail}`
-}
-
-function pipelineDiagnostic(
-  attempt: CameraAttempt,
-  readerModuleState: ReaderModuleState,
-): CameraPipelineDiagnostic {
-  if (
-    (attempt.readerModuleState === "idle" ||
-      attempt.readerModuleState === "preparing") &&
-    readerModuleState !== "idle"
-  ) {
-    attempt.readerModuleState = readerModuleState
-  }
-  return {
-    readerModuleState: attempt.readerModuleState,
-    videoFramesDrawn: attempt.videoFramesDrawn,
-    decodeAttemptsCompleted: attempt.decodeAttemptsCompleted,
-    decodeResultsSeen: attempt.decodeResultsSeen,
-    lastErrorName: attempt.lastErrorName,
-  }
-}
-
-export function publishPipelineDiagnostic(
-  attempt: CameraAttempt,
-  readerModuleState: ReaderModuleState = attempt.readerModuleState,
-): void {
-  if (!isActiveAttempt(attempt) || attempt.onDiagnostic === undefined) return
-  try {
-    attempt.onDiagnostic(pipelineDiagnostic(attempt, readerModuleState))
-  } catch {
-    // Diagnostics must never become another scanner failure path.
-  }
-}
-
-export function cameraDiagnostic(
-  attempt: CameraAttempt,
-  name: string | null,
-  phase: CameraDiagnosticPhase = attempt.phase,
-): CameraDiagnostic {
-  return {
-    phase,
-    name,
-    detail: diagnosticDetail(attempt),
-  }
 }
 
 export function cameraError(error: unknown): ConcreteAppError {

--- a/src/qr/camera/frame-pump.ts
+++ b/src/qr/camera/frame-pump.ts
@@ -13,12 +13,9 @@ import {
 } from "@/qr/camera/acquire"
 import { isActiveAttempt } from "@/qr/camera/attempt-registry"
 import {
-  cameraDiagnostic,
   cameraError,
   cameraTrack,
-  diagnosticName,
   isFrameNotReadyDecodeError,
-  publishPipelineDiagnostic,
   videoDimension,
 } from "@/qr/camera/diagnostics"
 import {
@@ -66,18 +63,13 @@ function clearDecodeProgressTimeout(attempt: CameraAttempt): void {
 
 function clearFrameRecovery(attempt: CameraAttempt): void {
   attempt.frameRecoveryActive = false
-  attempt.lastFrameErrorName = undefined
   clearFrameReadyTimeout(attempt)
 }
 
 function failDecode(attempt: CameraAttempt, error: unknown): void {
   if (!isActiveAttempt(attempt)) return
   const mapped = cameraError(error)
-  reportAttemptError(
-    attempt,
-    mapped,
-    cameraDiagnostic(attempt, diagnosticName(error), attempt.phase),
-  )
+  reportAttemptError(attempt, mapped)
   stopAttempt(attempt)
 }
 
@@ -91,11 +83,8 @@ function armDecodeProgressWatchdog(attempt: CameraAttempt): void {
   }, CAMERA_DECODE_PROGRESS_TIMEOUT_MS)
 }
 
-function completeDecodeAttempt(attempt: CameraAttempt, resultsSeen: number): void {
-  attempt.decodeAttemptsCompleted += 1
-  attempt.decodeResultsSeen += resultsSeen
+function completeDecodeAttempt(attempt: CameraAttempt): void {
   armDecodeProgressWatchdog(attempt)
-  publishPipelineDiagnostic(attempt)
 }
 
 function ensureFrameReadyTimeout(attempt: CameraAttempt): void {
@@ -106,21 +95,14 @@ function ensureFrameReadyTimeout(attempt: CameraAttempt): void {
     if (cameraTrack(attempt)?.readyState !== "live") return
 
     const mapped = new ConcreteAppError("CAMERA_NOT_AVAILABLE")
-    reportAttemptError(
-      attempt,
-      mapped,
-      cameraDiagnostic(attempt, attempt.lastFrameErrorName ?? "unknown", "playing"),
-    )
+    reportAttemptError(attempt, mapped)
     stopAttempt(attempt)
   }, CAMERA_FRAME_READY_TIMEOUT_MS)
 }
 
-function beginFrameRecovery(attempt: CameraAttempt, error: unknown): void {
+function beginFrameRecovery(attempt: CameraAttempt): void {
   if (!isActiveAttempt(attempt)) return
   attempt.frameRecoveryActive = true
-  attempt.lastFrameErrorName = diagnosticName(error)
-  attempt.lastErrorName = attempt.lastFrameErrorName
-  publishPipelineDiagnostic(attempt)
   ensureFrameReadyTimeout(attempt)
   retryVideoPlayback(attempt)
 }
@@ -302,10 +284,8 @@ async function decodeFrame(context: ScanContext): Promise<void> {
       dimensions.width,
       dimensions.height,
     )
-    context.attempt.videoFramesDrawn += 1
     // A successful draw proves scheduling progress and starts a fresh decode window.
     armDecodeProgressWatchdog(context.attempt)
-    publishPipelineDiagnostic(context.attempt)
     clearFrameRecovery(context.attempt)
 
     const imageData = context.frameContext.getImageData(
@@ -321,7 +301,7 @@ async function decodeFrame(context: ScanContext): Promise<void> {
     const results = await readBarcodes(imageData, zxingReaderOptions)
     if (!isActiveAttempt(context.attempt)) return
     decodeCallCompleted = true
-    completeDecodeAttempt(context.attempt, results.length)
+    completeDecodeAttempt(context.attempt)
 
     const result = results[0]
     if (result === undefined) return
@@ -339,10 +319,10 @@ async function decodeFrame(context: ScanContext): Promise<void> {
   } catch (error) {
     if (!isActiveAttempt(context.attempt)) return
     if (decodeCallStarted && !decodeCallCompleted) {
-      completeDecodeAttempt(context.attempt, 0)
+      completeDecodeAttempt(context.attempt)
     }
     if (isFrameNotReadyDecodeError(context.attempt, error)) {
-      beginFrameRecovery(context.attempt, error)
+      beginFrameRecovery(context.attempt)
       return
     }
     failDecode(context.attempt, error)
@@ -375,7 +355,6 @@ export async function startAttempt(
   }
 
   attempt.stream = stream
-  attempt.phase = "acquired"
   watchTrackEnds(attempt, stream)
   if (!isActiveAttempt(attempt)) throw new AttemptCancelled()
   attempt.video.srcObject = stream
@@ -409,9 +388,7 @@ export async function startAttempt(
   attempt.controls = pump
   attempt.decodePumpStarted = true
   armDecodeProgressWatchdog(attempt)
-  attempt.phase = "playing"
   attempt.frameRecoveryActive = true
-  attempt.lastFrameErrorName = undefined
   ensureFrameReadyTimeout(attempt)
   attempt.retryDecoder = () => scheduleNextFrame(context, Date.now(), true)
   // Preserve the initial rVFC grace period; the frame-readiness watchdog is already

--- a/src/qr/camera/reader-module.ts
+++ b/src/qr/camera/reader-module.ts
@@ -7,8 +7,7 @@ import {
 import wasmUrl from "zxing-wasm/reader/zxing_reader.wasm?url"
 
 import { hasWebAssemblyInstantiationApi } from "@/lib/feature-detect"
-import { currentAttempt } from "@/qr/camera/attempt-registry"
-import type { CameraAttempt, ReaderModuleState } from "@/qr/camera/types"
+import type { ReaderModuleState } from "@/qr/camera/types"
 
 export const CAMERA_START_TIMEOUT_MS = 8_000
 export const CAMERA_FRAME_READY_TIMEOUT_MS = 6_000
@@ -19,11 +18,6 @@ export const CAMERA_READER_READY_TIMEOUT_MS = 30_000
 // Two frame-readiness windows remain far beyond the healthy 200 ms empty-decode
 // cadence while bounding a readBarcodes call that never settles.
 export const CAMERA_DECODE_PROGRESS_TIMEOUT_MS = CAMERA_FRAME_READY_TIMEOUT_MS * 2
-
-export type PipelineDiagnosticPublisher = (
-  attempt: CameraAttempt,
-  readerModuleState?: ReaderModuleState,
-) => void
 
 const zxingModuleOverrides: ZXingModuleOverrides = {
   locateFile(path: string, scriptDirectory: string) {
@@ -59,9 +53,7 @@ export function readerModuleState(): ReaderModuleState {
 // Start or reuse WASM preparation. The shared readiness gate awaits this before
 // enabling capture; startQrScan refuses every non-ready state before camera
 // acquisition so a purged failed generation cannot reach the CDN default.
-export function prepareQrReaderModule(
-  publishPipelineDiagnostic: PipelineDiagnosticPublisher,
-): Promise<void> {
+export function prepareQrReaderModule(): Promise<void> {
   // Latched for the life of the document: the reported failure mode does not
   // recover in-page, and re-preparing only produces a second stalled generation.
   if (zxingModuleFailure !== undefined) return zxingModuleFailure
@@ -99,29 +91,22 @@ export function prepareQrReaderModule(
 
   const preparation = started.then(() => {
     zxingModuleState = "ready"
-    const attempt = currentAttempt()
-    if (attempt !== null) publishPipelineDiagnostic(attempt, zxingModuleState)
   })
   zxingModulePromise = preparation
   // Latch the failure for this document and swallow the rejection here: the seeding
-  // call in startQrScan deliberately does not await it. Cleanup runs to completion
-  // before the diagnostic so callbacks observe the terminal generation.
+  // call in startQrScan deliberately does not await it.
   void preparation.catch(() => {
     if (zxingModulePromise !== preparation) return
     zxingModuleFailure = preparation
     zxingModulePromise = undefined
     zxingModuleState = "failed"
     purgeZXingModule()
-    const attempt = currentAttempt()
-    if (attempt !== null) publishPipelineDiagnostic(attempt, zxingModuleState)
   })
   return preparation
 }
 
 // Fetch and compile the reader ahead of any tap. The readiness gate awaits the returned
 // promise and presents a latched failure instead of starting another generation in-page.
-export function warmQrReaderModule(
-  publishPipelineDiagnostic: PipelineDiagnosticPublisher,
-): Promise<void> {
-  return prepareQrReaderModule(publishPipelineDiagnostic)
+export function warmQrReaderModule(): Promise<void> {
+  return prepareQrReaderModule()
 }

--- a/src/qr/camera/types.ts
+++ b/src/qr/camera/types.ts
@@ -7,40 +7,20 @@ export interface QrScanHandle {
 
 export type ReaderModuleState = "idle" | "preparing" | "ready" | "failed"
 
-export interface CameraPipelineDiagnostic {
-  readerModuleState: ReaderModuleState
-  videoFramesDrawn: number
-  decodeAttemptsCompleted: number
-  decodeResultsSeen: number
-  lastErrorName: string | null
-}
-
 export interface StartQrScanOptions {
   // Defaults to true: stop automatically after the first success and ignore later
   // detections to prevent duplicate reads.
   once?: boolean
   signal?: AbortSignal
-  onDiagnostic?: (diagnostic: CameraPipelineDiagnostic) => void
 }
 
-export type CameraDiagnosticPhase =
-  | "acquiring"
-  | "acquired"
-  | "playing"
-  | "track-ended"
-
-export interface CameraDiagnostic {
-  phase: CameraDiagnosticPhase
-  name: string | null
-  detail: string
-}
+export type CameraFailureState = "failed" | "track-ended"
 
 export type CameraScanState =
   | "idle"
   | "acquiring"
   | "playing"
-  | "failed"
-  | "track-ended"
+  | CameraFailureState
 
 export interface ScannerControls {
   stop(): void
@@ -66,13 +46,9 @@ export interface ScanContext {
 export interface CameraAttempt {
   readonly id: number
   readonly video: HTMLVideoElement
-  readonly onError: (error: AppError, diagnostic: CameraDiagnostic) => void
-  readonly onDiagnostic:
-    | ((diagnostic: CameraPipelineDiagnostic) => void)
-    | undefined
+  readonly onError: (error: AppError, failureState: CameraFailureState) => void
   readonly stoppedPromise: Promise<void>
   resolveStopped(): void
-  phase: CameraDiagnosticPhase
   stopped: boolean
   emitted: boolean
   errorReported: boolean
@@ -93,12 +69,6 @@ export interface CameraAttempt {
   decodeProgressTimeoutId: ReturnType<typeof setTimeout> | undefined
   frameRecoveryActive: boolean
   decodePumpStarted: boolean
-  readerModuleState: ReaderModuleState
-  videoFramesDrawn: number
-  decodeAttemptsCompleted: number
-  decodeResultsSeen: number
-  lastErrorName: string | null
-  lastFrameErrorName: string | undefined
   retryDecoder: (() => void) | undefined
   abortSignal: AbortSignal | undefined
   abortListener: EventListener | undefined

--- a/src/qr/decode.ts
+++ b/src/qr/decode.ts
@@ -11,12 +11,7 @@ import {
   currentAttempt,
   isActiveAttempt,
 } from "@/qr/camera/attempt-registry"
-import {
-  cameraDiagnostic,
-  cameraError,
-  diagnosticName,
-  publishPipelineDiagnostic,
-} from "@/qr/camera/diagnostics"
+import { cameraError } from "@/qr/camera/diagnostics"
 import { startAttempt } from "@/qr/camera/frame-pump"
 import {
   CAMERA_START_TIMEOUT_MS,
@@ -27,7 +22,7 @@ import {
 import { AttemptCancelled } from "@/qr/camera/types"
 import type {
   CameraAttempt,
-  CameraDiagnostic,
+  CameraFailureState,
   CameraScanState,
   QrScanHandle,
   ScannerControls,
@@ -43,9 +38,7 @@ export {
 export { readerModuleState }
 
 export type {
-  CameraDiagnostic,
-  CameraDiagnosticPhase,
-  CameraPipelineDiagnostic,
+  CameraFailureState,
   CameraScanState,
   QrScanHandle,
   ReaderModuleState,
@@ -55,7 +48,7 @@ export type {
 // Fetch and compile the reader ahead of any tap. The shared readiness gate awaits this
 // promise before enabling capture and owns presentation of a latched failure.
 export function warmQrReader(): Promise<void> {
-  return warmQrReaderModule(publishPipelineDiagnostic)
+  return warmQrReaderModule()
 }
 
 // true does not automatically restart; it directs the UI to transition to stopped
@@ -79,7 +72,7 @@ type AttemptOutcome =
 async function startQrScanImplementation(
   video: HTMLVideoElement,
   onText: (text: string) => void,
-  onError: (error: AppError, diagnostic: CameraDiagnostic) => void,
+  onError: (error: AppError, failureState: CameraFailureState) => void,
   options?: StartQrScanOptions,
 ): Promise<QrScanHandle> {
   // The UI gate is not the security boundary: future direct callers must not
@@ -100,10 +93,8 @@ async function startQrScanImplementation(
     id: createAttemptId(),
     video,
     onError,
-    onDiagnostic: options?.onDiagnostic,
     stoppedPromise,
     resolveStopped,
-    phase: "acquiring",
     stopped: false,
     emitted: false,
     errorReported: false,
@@ -117,12 +108,6 @@ async function startQrScanImplementation(
     decodeProgressTimeoutId: undefined,
     frameRecoveryActive: false,
     decodePumpStarted: false,
-    readerModuleState: "idle",
-    videoFramesDrawn: 0,
-    decodeAttemptsCompleted: 0,
-    decodeResultsSeen: 0,
-    lastErrorName: null,
-    lastFrameErrorName: undefined,
     retryDecoder: undefined,
     abortSignal: undefined,
     abortListener: undefined,
@@ -150,9 +135,7 @@ async function startQrScanImplementation(
 
   // Reuse the already-ready generation. The fail-closed check above guarantees
   // that a latched failure cannot reach zxing-wasm after its module was purged.
-  prepareQrReaderModule(publishPipelineDiagnostic)
-  attempt.readerModuleState = readerModuleState()
-  publishPipelineDiagnostic(attempt)
+  prepareQrReaderModule()
 
   const operation: Promise<AttemptOutcome> = startAttempt(
     attempt,
@@ -169,7 +152,7 @@ async function startQrScanImplementation(
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<AttemptOutcome>((resolve) => {
     timeoutId = setTimeout(() => {
-      // Once the pump owns a decode-progress watchdog, let its distinct diagnostic
+      // Once the pump owns a decode-progress watchdog, let its distinct error
       // resolve a stalled playback/scheduler path instead of collapsing it into the
       // generic startup timeout.
       if (attempt.decodePumpStarted) return
@@ -189,7 +172,7 @@ async function startQrScanImplementation(
 
     if (outcome.kind === "timeout") {
       const mapped = new ConcreteAppError("CAMERA_NOT_AVAILABLE")
-      reportAttemptError(attempt, mapped, cameraDiagnostic(attempt, "unknown"))
+      reportAttemptError(attempt, mapped)
       stopAttempt(attempt)
       throw mapped
     }
@@ -203,11 +186,7 @@ async function startQrScanImplementation(
     }
 
     const mapped = cameraError(outcome.error)
-    reportAttemptError(
-      attempt,
-      mapped,
-      cameraDiagnostic(attempt, diagnosticName(outcome.error)),
-    )
+    reportAttemptError(attempt, mapped)
     stopAttempt(attempt)
     throw mapped
   } finally {

--- a/tests/ui/helpers/fakes.ts
+++ b/tests/ui/helpers/fakes.ts
@@ -444,19 +444,7 @@ export const exportQrFramePayloads = vi.fn(
 )
 export const copyTextToClipboard = vi.fn(async () => undefined)
 
-interface FakeCameraDiagnostic {
-  phase: "acquiring" | "acquired" | "playing" | "track-ended"
-  name: string | null
-  detail: string
-}
-
-interface FakeCameraPipelineDiagnostic {
-  readerModuleState: "idle" | "preparing" | "ready" | "failed"
-  videoFramesDrawn: number
-  decodeAttemptsCompleted: number
-  decodeResultsSeen: number
-  lastErrorName: string | null
-}
+type FakeCameraFailureState = "failed" | "track-ended"
 
 export const scannerStop = vi.fn()
 export const CAMERA_READER_READY_TIMEOUT_MS = 30_000
@@ -466,20 +454,16 @@ export const readerModuleState = vi.fn<
 export const warmQrReader = vi.fn<() => Promise<void>>(() => Promise.resolve())
 let scanTextCallback: ((payload: string) => void) | null = null
 let scanErrorCallback:
-  | ((error: FakeAppError, diagnostic: FakeCameraDiagnostic) => void)
+  | ((error: FakeAppError, failureState: FakeCameraFailureState) => void)
   | null = null
 export const startQrScan = vi.fn(
   async (
     _video: HTMLVideoElement,
     onText: (payload: string) => void,
-    onError: (
-      error: FakeAppError,
-      diagnostic: FakeCameraDiagnostic,
-    ) => void,
+    onError: (error: FakeAppError, failureState: FakeCameraFailureState) => void,
     _options?: {
       once?: boolean
       signal?: AbortSignal
-      onDiagnostic?: (diagnostic: FakeCameraPipelineDiagnostic) => void
     },
   ): Promise<{ stop: () => void }> => {
     void _options
@@ -493,13 +477,9 @@ export function emitScannedPayload(payload: string): void {
 }
 export function emitScanError(
   code: ErrorCode,
-  diagnostic: FakeCameraDiagnostic = {
-    phase: "acquiring",
-    name: null,
-    detail: "0x0 rs=0 track=none",
-  },
+  failureState: FakeCameraFailureState = "failed",
 ): void {
-  scanErrorCallback?.(new FakeAppError(code), diagnostic)
+  scanErrorCallback?.(new FakeAppError(code), failureState)
 }
 
 export const disposePqClient = vi.fn()

--- a/tests/ui/qr-scanner.test.tsx
+++ b/tests/ui/qr-scanner.test.tsx
@@ -20,7 +20,7 @@ import {
 import { AppError, messageFor } from "@/crypto/errors"
 import { MultipartScanSession } from "@/features/multipart-scan-session"
 import { translate } from "@/i18n/messages"
-import type { CameraDiagnostic, QrScanHandle } from "@/qr/decode"
+import type { QrScanHandle } from "@/qr/decode"
 import type { TransferState } from "@/qr/multipart/transfer-state"
 import {
   emitScannedPayload,
@@ -433,20 +433,6 @@ describe("QrScannerPanel single scan and camera lifecycle", () => {
     await waitFor(() => expect(startQrScan).toHaveBeenCalledOnce())
     expect(startQrScan.mock.calls[0]?.[3]).toMatchObject({ once: false })
     expect(startQrScan.mock.calls[0]?.[3]?.signal?.aborted).toBe(false)
-    act(() => {
-      startQrScan.mock.calls[0]?.[3]?.onDiagnostic?.({
-        readerModuleState: "preparing",
-        videoFramesDrawn: 0,
-        decodeAttemptsCompleted: 0,
-        decodeResultsSeen: 0,
-        lastErrorName: null,
-      })
-    })
-    expect(
-      screen.getByText(
-        "Pipeline: module=preparing frames=0 attempts=0 results=0 last=none",
-      ),
-    ).toBeInTheDocument()
 
     await act(async () => emitScannedPayload("OCM1:message"))
     await act(async () => emitScannedPayload("OCM1:message"))
@@ -562,21 +548,10 @@ describe("QrScannerPanel single scan and camera lifecycle", () => {
     ).toBeEnabled()
   })
 
-  it("shows the camera user message and diagnostic before an explicit restart", async () => {
+  it("shows the camera user message before an explicit restart", async () => {
     const cameraError = new AppError("CAMERA_NOT_AVAILABLE")
-    startQrScan.mockImplementationOnce(async (_video, _onText, onError, options) => {
-      options?.onDiagnostic?.({
-        readerModuleState: "ready",
-        videoFramesDrawn: 12,
-        decodeAttemptsCompleted: 11,
-        decodeResultsSeen: 0,
-        lastErrorName: "NotReadableError",
-      })
-      onError(cameraError, {
-        phase: "track-ended",
-        name: "NotReadableError",
-        detail: "0x0 rs=2 track=ended/unmuted",
-      })
+    startQrScan.mockImplementationOnce(async (_video, _onText, onError) => {
+      onError(cameraError, "track-ended")
       throw cameraError
     })
     const user = userEvent.setup()
@@ -587,16 +562,6 @@ describe("QrScannerPanel single scan and camera lifecycle", () => {
     await user.click(screen.getByRole("button", { name: "Start camera" }))
     expect(
       await screen.findByText(messageFor(cameraError.code, "en")),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        "Diagnostic: NotReadableError @track-ended [0x0 rs=2 track=ended/unmuted]",
-      ),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        "Pipeline: module=ready frames=12 attempts=11 results=0 last=NotReadableError",
-      ),
     ).toBeInTheDocument()
     expect(startQrScan).toHaveBeenCalledOnce()
 
@@ -610,7 +575,7 @@ describe("QrScannerPanel single scan and camera lifecycle", () => {
     const newStop = vi.fn()
     let oldText: ((payload: string) => void) | undefined
     let oldError:
-      | ((error: AppError, diagnostic: CameraDiagnostic) => void)
+      | ((error: AppError, failureState: "failed" | "track-ended") => void)
       | undefined
     let newText: ((payload: string) => void) | undefined
     startQrScan
@@ -634,11 +599,7 @@ describe("QrScannerPanel single scan and camera lifecycle", () => {
     )
     await user.click(screen.getByRole("button", { name: "Start camera" }))
     act(() => {
-      oldError?.(new AppError("CAMERA_NOT_AVAILABLE"), {
-        phase: "acquiring",
-        name: null,
-        detail: "0x0 rs=0 track=none",
-      })
+      oldError?.(new AppError("CAMERA_NOT_AVAILABLE"), "failed")
     })
     await user.click(
       await screen.findByRole("button", { name: "Restart camera" }),

--- a/tests/unit/qr-scanner.test.ts
+++ b/tests/unit/qr-scanner.test.ts
@@ -402,7 +402,6 @@ describe("camera scanner lifecycle", () => {
     })
     getUserMedia.mockResolvedValue(mediaStream(track))
     const onError = vi.fn()
-    const onDiagnostic = vi.fn()
     const decoder = await loadDecoder()
     const nativeSetTimeout = globalThis.setTimeout
     let suppressedTimerHandle = 1_000_000
@@ -430,7 +429,7 @@ describe("camera scanner lifecycle", () => {
       asVideoElement(fakeVideo),
       vi.fn(),
       onError,
-      { once: false, onDiagnostic },
+      { once: false },
     )
     await flushMicrotasks()
 
@@ -444,19 +443,8 @@ describe("camera scanner lifecycle", () => {
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "QR_DECODE_PROGRESS_TIMEOUT" }),
-      {
-        phase: "playing",
-        name: "QrDecodeProgressTimeout",
-        detail: "640x480 rs=2 track=live/unmuted",
-      },
+      "failed",
     )
-    expect(onDiagnostic).toHaveBeenLastCalledWith({
-      readerModuleState: "ready",
-      videoFramesDrawn: 0,
-      decodeAttemptsCompleted: 0,
-      decodeResultsSeen: 0,
-      lastErrorName: "QrDecodeProgressTimeout",
-    })
     expect(zxing.readBarcodes).not.toHaveBeenCalled()
     expect(track.stop).toHaveBeenCalledOnce()
     expect(vi.getTimerCount()).toBe(0)
@@ -671,11 +659,7 @@ describe("camera scanner lifecycle", () => {
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
-      {
-        phase: "playing",
-        name: "IndexSizeError",
-        detail: "0x0 rs=2 track=live/unmuted",
-      },
+      "failed",
     )
     expect(zxing.readBarcodes).not.toHaveBeenCalled()
     expect(fakeVideo.play).toHaveBeenCalled()
@@ -807,11 +791,7 @@ describe("camera scanner lifecycle", () => {
     expect(onError).toHaveBeenCalledOnce()
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
-      {
-        phase: "track-ended",
-        name: null,
-        detail: "640x480 rs=2 track=ended/unmuted",
-      },
+      "track-ended",
     )
     expect(track.stop).toHaveBeenCalledOnce()
     handle.stop()
@@ -898,11 +878,7 @@ describe("camera scanner lifecycle", () => {
     expect(oldText).not.toHaveBeenCalled()
     expect(replacementError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "QR_DECODE_PROGRESS_TIMEOUT" }),
-      {
-        phase: "playing",
-        name: "QrDecodeProgressTimeout",
-        detail: "640x480 rs=2 track=live/unmuted",
-      },
+      "failed",
     )
     expect(oldTrack.stop).toHaveBeenCalledOnce()
     expect(replacementTrack.stop).toHaveBeenCalledOnce()
@@ -950,11 +926,7 @@ describe("camera scanner lifecycle", () => {
     expect(oldText).not.toHaveBeenCalled()
     expect(replacementError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
-      {
-        phase: "acquiring",
-        name: "unknown",
-        detail: "640x480 rs=2 track=none",
-      },
+      "failed",
     )
     expect(oldTrack.stop).toHaveBeenCalledOnce()
     expect(replacementTrack.stop).not.toHaveBeenCalled()
@@ -1112,7 +1084,6 @@ describe("camera scanner lifecycle", () => {
   it("keeps completing empty decode attempts across many watchdog windows", async () => {
     const track = new FakeTrack()
     const onError = vi.fn()
-    const onDiagnostic = vi.fn()
     getUserMedia.mockResolvedValue(mediaStream(track))
     zxing.readBarcodes.mockResolvedValue([])
     const decoder = await loadDecoder()
@@ -1121,7 +1092,7 @@ describe("camera scanner lifecycle", () => {
       videoElement(),
       vi.fn(),
       onError,
-      { once: false, onDiagnostic },
+      { once: false },
     )
 
     await advance(decoder.CAMERA_DECODE_PROGRESS_TIMEOUT_MS * 10)
@@ -1129,13 +1100,6 @@ describe("camera scanner lifecycle", () => {
     expect(zxing.readBarcodes.mock.calls.length).toBeGreaterThan(100)
     expect(onError).not.toHaveBeenCalled()
     expect(track.stop).not.toHaveBeenCalled()
-    expect(onDiagnostic).toHaveBeenLastCalledWith({
-      readerModuleState: "ready",
-      videoFramesDrawn: zxing.readBarcodes.mock.calls.length,
-      decodeAttemptsCompleted: zxing.readBarcodes.mock.calls.length,
-      decodeResultsSeen: 0,
-      lastErrorName: null,
-    })
 
     handle.stop()
     expect(track.stop).toHaveBeenCalledOnce()
@@ -1189,7 +1153,7 @@ describe("camera scanner lifecycle", () => {
       },
     },
   ])(
-    "stops with playing diagnostics when readBarcodes $behavior",
+    "stops with a camera error when readBarcodes $behavior",
     async ({ name, arrange }) => {
       const track = new FakeTrack()
       getUserMedia.mockResolvedValue(mediaStream(track))
@@ -1209,11 +1173,7 @@ describe("camera scanner lifecycle", () => {
 
       expect(onError).toHaveBeenCalledWith(
         expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
-        {
-          phase: "playing",
-          name,
-          detail: "640x480 rs=2 track=live/unmuted",
-        },
+        "failed",
       )
       expect(track.stop).toHaveBeenCalledOnce()
       expect(vi.getTimerCount()).toBe(0)
@@ -1302,11 +1262,7 @@ describe("camera scanner lifecycle", () => {
     expect(getUserMedia).toHaveBeenCalledTimes(4)
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
-      {
-        phase: "acquiring",
-        name: "NotReadableError",
-        detail: "640x480 rs=2 track=none",
-      },
+      "failed",
     )
   })
 
@@ -1445,7 +1401,7 @@ describe("camera scanner lifecycle", () => {
     expect(getUserMedia).not.toHaveBeenCalled()
   })
 
-  it("never carries a scanned payload into a diagnostic", async () => {
+  it("reports a scanned-payload callback failure as a camera error", async () => {
     getUserMedia.mockResolvedValue(mediaStream(new FakeTrack()))
     zxing.readBarcodes.mockResolvedValue(barcode("OCK1:SENTINEL-SECRET"))
     const onError = vi.fn()
@@ -1462,10 +1418,10 @@ describe("camera scanner lifecycle", () => {
     await advance(0)
     await flushMicrotasks()
 
-    expect(onError).toHaveBeenCalled()
-    for (const call of onError.mock.calls) {
-      expect(JSON.stringify(call[1])).not.toContain("SENTINEL-SECRET")
-    }
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "CAMERA_NOT_AVAILABLE" }),
+      "failed",
+    )
     handle.stop()
   })
 
@@ -1496,24 +1452,15 @@ describe("camera scanner lifecycle", () => {
 
   it("reuses a warm preparation instead of starting a second one", async () => {
     getUserMedia.mockResolvedValue(mediaStream(new FakeTrack()))
-    const onDiagnostic = vi.fn()
     const decoder = await loadDecoder()
 
     await decoder.warmQrReader()
     const handle = await decoder.startQrScan(videoElement(), vi.fn(), vi.fn(), {
       once: false,
-      onDiagnostic,
     })
     await advance(0)
 
     expect(zxing.prepareZXingModule).toHaveBeenCalledOnce()
-    expect(onDiagnostic.mock.calls[0]?.[0]).toEqual({
-      readerModuleState: "ready",
-      videoFramesDrawn: 0,
-      decodeAttemptsCompleted: 0,
-      decodeResultsSeen: 0,
-      lastErrorName: null,
-    })
     handle.stop()
   })
 })


### PR DESCRIPTION
## Why

The owner confirmed on device that #44 works: the scan control is briefly disabled on a
cold page and then starts on the first tap. The two on-screen diagnostic lines existed to
find that bug and the precache gap before it, and both are fixed.

## What changed

The debug display is gone, and so is everything that existed only to feed it: the pipeline
publisher, the camera diagnostic builder with its detail and message formatting, the
frame/attempt/result counters, `lastErrorName`, the attempt's copy of the reader module
state, `onDiagnostic` on both the scan options and the attempt, and `attempt.phase` —
nothing read that once the diagnostics went, because track-end already reaches the panel
through `reportAttemptError`. Six i18n keys leave both locales.

Net −412 lines.

## What stays

Control flow, not telemetry: `cameraError`, `diagnosticName`, `isTransientCameraAcquireError`,
`isFrameNotReadyDecodeError`, `cameraTrack`, `videoDimension`, every `AppError` code and the
user-facing error alert, the reader failed/blocked overlay with its reload control, and all
three watchdogs. The panel still says *why* a scan failed; it no longer says *how*.

## Trade-off, stated plainly

This removes the only on-device telemetry available to a user. If another device-specific
failure appears, the next diagnosis starts without the log that solved the last two.

## Verification

`make check` (727 tests) and `make e2e` (27) pass. The deletion grep returns nothing.
Reviewed independently by two panes: one found nothing at any severity, the other found one
minor unused export, fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
