### PR TITLE
docs: record the textbook-simplicity bar in the repository rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,15 @@ Build fully offline encryption engineered against nation-state cryptanalysis and
 
 - No backward compatibility. Installs never update, so no legacy value, migration, or rollback path.
 - On task completion, follow `.claude/skills/freshness/SKILL.md`: add new time-decaying files to `targets.yaml`; for listed files touched or invalidated, refresh and verify affected units; stamp only passed units; verify, never stamp, invariants.
+
+# Simplicity
+
+The bar is textbook: from one file alone, a competent engineer who has never seen this repository can name the single idea it embodies, predict its body from its name, and hold nothing else in their head.
+
+- A cold reading decides local comprehensibility and nothing else. "What breaks without it?" is a repository-level question and the reader has one file, so a reader who answers "nothing" is following the procedure correctly and is often wrong. `delete` and `fold` are candidate labels, never prescriptions; `rewrite` needs no evidence beyond the reading.
+- Delete only after proving reachability across `src` and `tests`, that no freshness unit or invariant names it, and stating the security consequence of its removal.
+- Fold only after a semantic-equivalence proof covering pending, already-resolved, cancellation, close/reopen, and error. That list is not generic: an argument that covered the unresolved async state and never examined the already-resolved one is how the one avoidable behavior regression shipped.
+- Hunt contradictions, not excess. Every real finding so far was two things disagreeing — two definitions of one function, two surfaces disagreeing about one switch — not too much code.
+- Move a concept between files only when two or more independent readers placed its pieces in different files. That is what separates a discovered boundary from an invented one.
+- State four things before any behavior change: what changes; who observes it, as a reachable path; direction, safer or less safe; what breaks under the opposite choice. Direction decides, not size.
+- Never a finding: anything `targets.yaml` marks append-only or frozen. Deleting one wipes stored preferences or breaks a golden; it does not simplify.


### PR DESCRIPTION
Adds a `# Simplicity` section to `CLAUDE.md` (and therefore `AGENTS.md`, which is a symlink to
it). Documentation only — no source, test, or configuration change.

## What it is

Two rounds of refactoring converged on a small set of rules. Every one of them was learned by
getting it wrong first, so they are written down to be inherited rather than re-derived.

Each line was selected by one test: would a competent session reach this conclusion on its own?
Anything that would was left out.

## The load-bearing line

A cold reading decides local comprehensibility and nothing else.

"What breaks without it?" is a repository-level question asked of a reader holding one file.
Callers, wire contracts, freshness invariants and threat-model decisions all live outside it, so
a reader who confidently answers "nothing" is following the procedure correctly and is often
wrong. An earlier version of the method mapped that answer straight to a deletion; both plan
reviewers rejected it independently, with the same counterexample — SHA-256 fakes whose reason
for existing is written in a different file.

Hence `delete` and `fold` are candidate labels rather than prescriptions, and each carries its
own evidence requirement.

## Why the fold rule keeps its provenance

The equivalence proof must cover pending, already-resolved, cancellation, close/reopen, and
error. That list is not generic, and the section says why: an argument that covered the
unresolved async state and never examined the already-resolved one is how the one avoidable
behavior regression shipped. Without the reason the fifth state reads as padding and gets
dropped.

## Deliberately not included

- The cold-reading programme's operating procedure — contract pre-registration, reader
  confidence, a second reader for every failure, `MISLEADING` adjudication, double-reading a
  sample of passes. That is scaffolding for one measurement, not a standing rule.
- Repository mechanics learned the same way: that adding a named export to a fully-mocked module
  breaks every UI test reaching it, that lint must be measured inside a worktree because
  `eslint.config.js` does not ignore `.worktrees/`, that worker counts are part of a test result.
  Those belong under `docs/develop/`, not in the rules.
- The argument for "textbook" over "world-class OSS". Semantic versioning, migration paths and
  deprecation cycles all presume installs that update, which the first rule already forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)