### PR TITLE
refactor(relay): fix a miscited threat-model row, bound the paste work, and give both leakage oracles one definition of payload

### DIFF
--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -306,20 +306,27 @@ guaranteed; JS memory erasure has limits
    is not sufficient: a regression that POSTed relay text to this origin
    would still be same-origin. e2e (`tests/e2e/security.spec.ts` and
    `tests/e2e/online-relay.spec.ts`) must assert:
-   - **Allowlist (methods + paths only):** static/PWA resources; recurring
-     `HEAD /manifest.webmanifest?reach=…` (display probe); boot
+   - **Allowlist (methods, paths, and query keys):** static/PWA resources;
+     recurring `HEAD /manifest.webmanifest?reach=…` (display probe); boot
      `GET /reachability-sentinel.txt` (destructive probe). No other
-     runtime requests.
+     runtime requests. Every allowed request must carry no query key beyond
+     the two named above — checking method and path alone would let an allowed
+     static GET carry a payload field in its query.
    - **Negative matrix after capture / copy / paste / playback / rejection /
      close / `pagehide` / timeout:** a unique relay payload marker and a
      marker from each sender-controlled OCM1 field plus the refused OCK1 key
-     bytes are absent from request bodies and query values, every IndexedDB
-     database's keys/values, CacheStorage metadata/bodies (static shell
-     permitted), localStorage (only `{oc-theme, oc-lang,
+     bytes are absent from request URLs including query names and values,
+     request header names and values, request bodies, every IndexedDB
+     database's schema names — database, object-store and index names and key
+     paths — as well as its keys/values, CacheStorage metadata/bodies (static
+     shell permitted), localStorage (only `{oc-theme, oc-lang,
      oc-offline-ack-pending, oc-online-tab}`), console, `window.onerror` /
      unhandled rejections, visible error text, `document.title`,
-     `location.href`, and history state. The byte-aware storage oracle has a
-     self-test that plants a typed-array marker and requires it to be found.
+     `location.href`, and history state. **One marker set covers every sink**;
+     a request oracle that searches fewer markers than the storage oracle is
+     the hole this line exists to close. The byte-aware storage oracle's
+     self-test plants both a typed-array value marker and a marker that appears
+     only in an object-store name, and requires exactly those two matches.
    - **Window-realm receipts must never appear in IndexedDB, localStorage, or
      CacheStorage.** Receipts are intentional module-memory residue in one loaded
      app window only (`src/features/receipt-cache.ts`), not shared with other tabs

--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -308,7 +308,7 @@ guaranteed; JS memory erasure has limits
    `tests/e2e/online-relay.spec.ts`) must assert:
    - **Allowlist (methods, paths, and query keys):** static/PWA resources;
      recurring `HEAD /manifest.webmanifest?reach=…` (display probe); boot
-     `GET /reachability-sentinel.txt` (destructive probe). No other
+     `GET /reachability-sentinel.txt?n=…` (destructive probe). No other
      runtime requests. Every allowed request must carry no query key beyond
      the two named above — checking method and path alone would let an allowed
      static GET carry a payload field in its query.

--- a/src/qr/relay-frames.ts
+++ b/src/qr/relay-frames.ts
@@ -192,12 +192,14 @@ export function orderedRelayEntries(set: RelayFrameSet): RelayFrameEntry[] {
 }
 
 /**
- * The relay's entire allowlist, in one place. Exactly two prefixes reach a
- * parser; every other prefix stops here, including the OCK1 symmetric key and
- * the OCP1 public key. Rejecting those prefixes is not a guarantee that no key
- * material crosses the relay. Accepted OCF2 chunks and every sender-controlled
- * OCM1 field (`keyId`, `createdAt`, `iv`, `ciphertext`, and `aad`) are untrusted;
- * the offline endpoint is the only authentication boundary (threat-model T21).
+ * The relay's prefix gate. `parseRelayFrameSet` enforces the OCF2 outer type,
+ * and `parseRelayMessage` enforces OCM1 structure and canonical form. Exactly
+ * two prefixes reach those parsers; every other prefix stops here, including
+ * the OCK1 symmetric key and the OCP1 public key. Rejecting those prefixes does
+ * not guarantee that no key material crosses the relay: accepted OCF2 chunks
+ * and every sender-controlled OCM1 field (`keyId`, `createdAt`, `iv`,
+ * `ciphertext`, and `aad`) remain untrusted, and the offline endpoint is the
+ * only authentication boundary (threat-model T19).
  */
 function classifyRelayLine(text: string): "message" | "frames" | null {
   if (text.startsWith(QR_PREFIX.message)) return "message"
@@ -309,8 +311,20 @@ export function parseRelayText(text: string): RelayTextParseResult {
     .map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line))
     .filter((line) => line.length > 0)
   if (originals.length === 0) return { ok: false, code: "empty" }
-  if (originals.some((original) => classifyRelayLine(original) === null)) {
+  const kinds = originals.map(classifyRelayLine)
+  if (kinds.some((kind) => kind === null)) {
     return { ok: false, code: "prefix" }
+  }
+
+  const messageCount = kinds.filter((kind) => kind === "message").length
+  if (messageCount > 1) {
+    return { ok: false, code: "message-count" }
+  }
+  if (messageCount === 1 && kinds.some((kind) => kind === "frames")) {
+    return { ok: false, code: "kind-mismatch" }
+  }
+  if (originals.length > PROTOCOL_MAX_FRAMES) {
+    return { ok: false, code: "frame-count" }
   }
 
   const validated: ValidatedRelayLine[] = []
@@ -324,21 +338,8 @@ export function parseRelayText(text: string): RelayTextParseResult {
     (candidate): candidate is Extract<ValidatedRelayLine, { kind: "message" }> =>
       candidate.ok && candidate.kind === "message",
   )
-  if (messages.length > 1) {
-    return { ok: false, code: "message-count" }
-  }
-  if (
-    messages.length === 1 &&
-    validated.some((candidate) => candidate.ok && candidate.kind === "frames")
-  ) {
-    return { ok: false, code: "kind-mismatch" }
-  }
   if (messages[0] !== undefined) {
     return { ok: true, kind: "message", payload: messages[0].payload }
-  }
-
-  if (originals.length > PROTOCOL_MAX_FRAMES) {
-    return { ok: false, code: "frame-count" }
   }
 
   const parsed = parseRelayFrameSet(originals)

--- a/tests/e2e/online-relay.spec.ts
+++ b/tests/e2e/online-relay.spec.ts
@@ -26,18 +26,33 @@ import { OCK1_SYMMETRIC_KEY } from "../fixtures/relay-v1"
 
 interface ObservedRequest {
   body: string | null
-  headers: Record<string, string>
+  fromServiceWorker: boolean
+  headers: { name: string; value: string }[]
   method: string
   url: string
 }
 
-function requestObservation(request: Request): ObservedRequest {
+async function requestObservation(request: Request): Promise<ObservedRequest> {
   return {
     body: request.postData(),
-    headers: request.headers(),
+    fromServiceWorker: request.serviceWorker() !== null,
+    headers: await request.headersArray(),
     method: request.method(),
     url: request.url(),
   }
+}
+
+async function awaitRequestObservations(
+  pending: readonly Promise<ObservedRequest>[],
+): Promise<ObservedRequest[]> {
+  const requests: ObservedRequest[] = []
+  let next = 0
+  while (next < pending.length) {
+    const batch = pending.slice(next)
+    next += batch.length
+    requests.push(...(await Promise.all(batch)))
+  }
+  return requests
 }
 
 function expectAllowedRelayRequest(request: ObservedRequest): void {
@@ -61,7 +76,10 @@ function expectAllowedRelayRequest(request: ObservedRequest): void {
       url.pathname === "/sw.js" ||
       url.pathname === "/registerSW.js" ||
       /^\/workbox-[A-Za-z0-9_-]+\.js$/.test(url.pathname) ||
-      /^\/(?:assets|icons)\//.test(url.pathname),
+      /^\/(?:assets|icons)\//.test(url.pathname) ||
+      (request.fromServiceWorker &&
+        (url.pathname === "/index.html" || url.pathname === "/favicon.svg")),
+    `Unexpected relay request: ${request.method} ${request.url}`,
   ).toBe(true)
 }
 
@@ -160,6 +178,18 @@ function expectNoRelayPayloadText(
   }
 }
 
+function expectNoRelayPayloadHeaders(
+  headers: readonly { name: string; value: string }[],
+  markers: readonly RelayPayloadMarker[],
+): void {
+  for (const { text } of markers) {
+    for (const { name, value } of headers) {
+      expect(name.toLowerCase()).not.toContain(text.toLowerCase())
+      expect(value).not.toContain(text)
+    }
+  }
+}
+
 async function assertNoRelayPayloadPersistence(
   page: Page,
   markers: readonly RelayPayloadMarker[],
@@ -212,7 +242,7 @@ async function assertNoRelayPayloadPersistence(
   expectNoRelayPayloadText(inspected, markers)
 }
 
-test("the relay persistence oracle detects binary and schema-name markers", async ({
+test("the relay persistence oracle detects binary, schema-name, and cookie markers", async ({
   page,
 }) => {
   const databaseName = "relay-persistence-oracle-self-test"
@@ -220,7 +250,17 @@ test("the relay persistence oracle detects binary and schema-name markers", asyn
   const storeName = `markers-${schemaMarker}`
   const marker = "RELAY_TYPED_ARRAY_ORACLE_7B4D"
   const markerBytes = Array.from(new TextEncoder().encode(marker))
+  const cookieName = "relay-persistence-oracle-self-test"
+  const cookieMarker = "RELAY_HTTP_ONLY_COOKIE_ORACLE_4F8A"
   await loadOnlineGate(page)
+  await page.context().addCookies([
+    {
+      name: cookieName,
+      value: cookieMarker,
+      url: page.url(),
+      httpOnly: true,
+    },
+  ])
   await page.evaluate(
     ({ bytes, name, store }) =>
       new Promise<void>((resolve, reject) => {
@@ -250,8 +290,9 @@ test("the relay persistence oracle detects binary and schema-name markers", asyn
     const inspection = await inspectPersistentSurfaces(page, [
       { marker: "typed-array-self-test", bytes: markerBytes },
       { marker: "schema-name-self-test", text: schemaMarker },
+      { marker: "cookie-self-test", text: cookieMarker },
     ])
-    expect(inspection.matches).toHaveLength(2)
+    expect(inspection.matches).toHaveLength(3)
     expect(inspection.matches).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -266,20 +307,27 @@ test("the relay persistence oracle detects binary and schema-name markers", asyn
             `indexedDB:${databaseName}/${storeName}.values[0]`,
           ),
         }),
+        expect.objectContaining({
+          marker: "cookie-self-test",
+          location: expect.stringContaining(`:${cookieName}.value:text`),
+        }),
       ]),
     )
   } finally {
-    await page.evaluate(
-      (name) =>
-        new Promise<void>((resolve, reject) => {
-          const deletion = indexedDB.deleteDatabase(name)
-          deletion.onerror = () => reject(deletion.error)
-          deletion.onblocked = () =>
-            reject(new Error(`IndexedDB deletion was blocked: ${name}`))
-          deletion.onsuccess = () => resolve()
-        }),
-      databaseName,
-    )
+    await Promise.all([
+      page.context().clearCookies({ name: cookieName }),
+      page.evaluate(
+        (name) =>
+          new Promise<void>((resolve, reject) => {
+            const deletion = indexedDB.deleteDatabase(name)
+            deletion.onerror = () => reject(deletion.error)
+            deletion.onblocked = () =>
+              reject(new Error(`IndexedDB deletion was blocked: ${name}`))
+            deletion.onsuccess = () => resolve()
+          }),
+        databaseName,
+      ),
+    ])
   }
 })
 
@@ -324,9 +372,11 @@ test("relays canonical OCM1 messages and OCF2 frames without relay-payload persi
     bytesToHex(SYMMETRIC_KEY_BYTES.subarray(0, 8)),
     Array.from(SYMMETRIC_KEY_BYTES.subarray(0, 8)).join(","),
   ]
-  const requests: ObservedRequest[] = []
+  const pendingRequestObservations: Promise<ObservedRequest>[] = []
   const consoleValues: string[] = []
-  page.on("request", (request) => requests.push(requestObservation(request)))
+  context.on("request", (request) =>
+    pendingRequestObservations.push(requestObservation(request)),
+  )
   page.on("console", (message) => consoleValues.push(message.text()))
   page.on("pageerror", (error) => consoleValues.push(error.message))
   await page.addInitScript(() => {
@@ -546,22 +596,22 @@ test("relays canonical OCM1 messages and OCF2 frames without relay-payload persi
       bytes: SYMMETRIC_KEY_BYTES,
     },
   ]
+  for (const value of consoleValues) {
+    expectNoRelayPayloadText([value], relayPayloadMarkers)
+  }
+  await assertNoRelayPayloadPersistence(page, relayPayloadMarkers)
+  const requests = await awaitRequestObservations(pendingRequestObservations)
+  expect(requests.some(({ fromServiceWorker }) => fromServiceWorker)).toBe(true)
   for (const request of requests) {
     expectAllowedRelayRequest(request)
     expectNoRelayPayloadText(
       [
         request.url,
-        ...Object.entries(request.headers).flatMap(([name, value]) => [
-          name,
-          value,
-        ]),
+        ...[...new URL(request.url).searchParams.entries()].flat(),
         request.body ?? "",
       ],
       relayPayloadMarkers,
     )
+    expectNoRelayPayloadHeaders(request.headers, relayPayloadMarkers)
   }
-  for (const value of consoleValues) {
-    expectNoRelayPayloadText([value], relayPayloadMarkers)
-  }
-  await assertNoRelayPayloadPersistence(page, relayPayloadMarkers)
 })

--- a/tests/e2e/online-relay.spec.ts
+++ b/tests/e2e/online-relay.spec.ts
@@ -26,6 +26,7 @@ import { OCK1_SYMMETRIC_KEY } from "../fixtures/relay-v1"
 
 interface ObservedRequest {
   body: string | null
+  headers: Record<string, string>
   method: string
   url: string
 }
@@ -33,6 +34,7 @@ interface ObservedRequest {
 function requestObservation(request: Request): ObservedRequest {
   return {
     body: request.postData(),
+    headers: request.headers(),
     method: request.method(),
     url: request.url(),
   }
@@ -50,6 +52,7 @@ function expectAllowedRelayRequest(request: ObservedRequest): void {
     expect([...url.searchParams.keys()]).toEqual(["reach"])
     return
   }
+  expect([...url.searchParams.keys()]).toEqual([])
   expect(request.method).toBe("GET")
   expect(
     url.pathname === "/" ||
@@ -144,18 +147,24 @@ function symmetricKeyPayload(): string {
   return OCK1_SYMMETRIC_KEY
 }
 
+interface RelayPayloadMarker extends PersistenceNeedle {
+  text: string
+}
+
+function expectNoRelayPayloadText(
+  values: readonly string[],
+  markers: readonly RelayPayloadMarker[],
+): void {
+  for (const { text } of markers) {
+    for (const value of values) expect(value).not.toContain(text)
+  }
+}
+
 async function assertNoRelayPayloadPersistence(
   page: Page,
-  textNeedles: readonly string[],
-  byteNeedles: readonly PersistenceNeedle[],
+  markers: readonly RelayPayloadMarker[],
 ): Promise<void> {
-  const persistence = await inspectPersistentSurfaces(page, [
-    ...textNeedles.map((text, index) => ({
-      marker: `relay-text-${index}`,
-      text,
-    })),
-    ...byteNeedles,
-  ])
+  const persistence = await inspectPersistentSurfaces(page, markers)
   expect(persistence.matches).toEqual([])
 
   const snapshot = await page.evaluate(() => {
@@ -200,29 +209,29 @@ async function assertNoRelayPayloadPersistence(
     snapshot.title,
     snapshot.visibleText,
   ]
-  for (const needle of textNeedles) {
-    for (const value of inspected) expect(value).not.toContain(needle)
-  }
+  expectNoRelayPayloadText(inspected, markers)
 }
 
-test("the relay persistence oracle detects a typed-array marker", async ({
+test("the relay persistence oracle detects binary and schema-name markers", async ({
   page,
 }) => {
   const databaseName = "relay-persistence-oracle-self-test"
+  const schemaMarker = "RELAY_SCHEMA_ORACLE_9C2A"
+  const storeName = `markers-${schemaMarker}`
   const marker = "RELAY_TYPED_ARRAY_ORACLE_7B4D"
   const markerBytes = Array.from(new TextEncoder().encode(marker))
   await loadOnlineGate(page)
   await page.evaluate(
-    ({ bytes, name }) =>
+    ({ bytes, name, store }) =>
       new Promise<void>((resolve, reject) => {
         const opening = indexedDB.open(name, 1)
         opening.onerror = () => reject(opening.error)
         opening.onupgradeneeded = () => {
-          opening.result.createObjectStore("markers")
+          opening.result.createObjectStore(store)
         }
         opening.onsuccess = () => {
           const database = opening.result
-          const transaction = database.transaction("markers", "readwrite")
+          const transaction = database.transaction(store, "readwrite")
           transaction.onerror = () => reject(transaction.error)
           transaction.onabort = () => reject(transaction.error)
           transaction.oncomplete = () => {
@@ -230,25 +239,35 @@ test("the relay persistence oracle detects a typed-array marker", async ({
             resolve()
           }
           transaction
-            .objectStore("markers")
+            .objectStore(store)
             .put(Uint8Array.from(bytes), "typed-array")
         }
       }),
-    { bytes: markerBytes, name: databaseName },
+    { bytes: markerBytes, name: databaseName, store: storeName },
   )
 
   try {
     const inspection = await inspectPersistentSurfaces(page, [
       { marker: "typed-array-self-test", bytes: markerBytes },
+      { marker: "schema-name-self-test", text: schemaMarker },
     ])
-    expect(inspection.matches).toEqual([
-      expect.objectContaining({
-        marker: "typed-array-self-test",
-        location: expect.stringContaining(
-          `indexedDB:${databaseName}/markers.values[0]`,
-        ),
-      }),
-    ])
+    expect(inspection.matches).toHaveLength(2)
+    expect(inspection.matches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          marker: "schema-name-self-test",
+          location: expect.stringContaining(
+            `indexedDB:${databaseName}/${storeName}:store-name`,
+          ),
+        }),
+        expect.objectContaining({
+          marker: "typed-array-self-test",
+          location: expect.stringContaining(
+            `indexedDB:${databaseName}/${storeName}.values[0]`,
+          ),
+        }),
+      ]),
+    )
   } finally {
     await page.evaluate(
       (name) =>
@@ -481,18 +500,13 @@ test("relays canonical OCM1 messages and OCF2 frames without relay-payload persi
   ).toBeVisible()
   expect((await injectedScanSnapshot(page)).every(({ active }) => !active)).toBe(true)
 
-  const relayPayloadNeedles = [
-    relayPayloadMarker,
-    framePayloads[0]!,
-    relayText,
-    canonicalMessagePayload,
-    ...decodedMessageMarkers,
-    canonicalSymmetricKeyPayload,
-    ...rawKeyMarkers,
-  ]
   const createdAtBytes = new Uint8Array(8)
   new DataView(createdAtBytes.buffer).setFloat64(0, V1_CREATED_AT)
-  const relayPayloadByteNeedles: PersistenceNeedle[] = [
+  const relayPayloadMarkers: RelayPayloadMarker[] = [
+    { marker: "invalid-ocf2-marker", text: relayPayloadMarker },
+    { marker: "ocf2-first-frame", text: framePayloads[0]! },
+    { marker: "ocf2-frame-set", text: relayText },
+    { marker: "ocm1-payload", text: canonicalMessagePayload },
     {
       marker: "ocm1-keyId",
       text: V1_KEY_ID,
@@ -503,26 +517,51 @@ test("relays canonical OCM1 messages and OCF2 frames without relay-payload persi
       text: String(V1_CREATED_AT),
       bytes: createdAtBytes,
     },
-    { marker: "ocm1-iv", bytes: MESSAGE_IV_BYTES },
-    { marker: "ocm1-ciphertext", bytes: MESSAGE_CIPHERTEXT_BYTES },
-    { marker: "ocm1-aad", bytes: MESSAGE_AAD_BYTES },
-    { marker: "ock1-key", bytes: SYMMETRIC_KEY_BYTES },
+    {
+      marker: "ocm1-iv",
+      text: bytesToHex(MESSAGE_IV_BYTES),
+      bytes: MESSAGE_IV_BYTES,
+    },
+    {
+      marker: "ocm1-ciphertext-prefix",
+      text: decodedMessageMarkers[1]!,
+    },
+    {
+      marker: "ocm1-ciphertext",
+      text: bytesToHex(MESSAGE_CIPHERTEXT_BYTES),
+      bytes: MESSAGE_CIPHERTEXT_BYTES,
+    },
+    {
+      marker: "ocm1-aad",
+      text: bytesToHex(MESSAGE_AAD_BYTES),
+      bytes: MESSAGE_AAD_BYTES,
+    },
+    { marker: "ock1-payload", text: canonicalSymmetricKeyPayload },
+    { marker: "ock1-key-text", text: rawKeyMarkers[0]! },
+    { marker: "ock1-key-prefix-hex", text: rawKeyMarkers[1]! },
+    { marker: "ock1-key-prefix-decimal", text: rawKeyMarkers[2]! },
+    {
+      marker: "ock1-key",
+      text: bytesToHex(SYMMETRIC_KEY_BYTES),
+      bytes: SYMMETRIC_KEY_BYTES,
+    },
   ]
   for (const request of requests) {
     expectAllowedRelayRequest(request)
-    for (const needle of relayPayloadNeedles) {
-      expect(request.url).not.toContain(needle)
-      expect(request.body ?? "").not.toContain(needle)
-    }
+    expectNoRelayPayloadText(
+      [
+        request.url,
+        ...Object.entries(request.headers).flatMap(([name, value]) => [
+          name,
+          value,
+        ]),
+        request.body ?? "",
+      ],
+      relayPayloadMarkers,
+    )
   }
   for (const value of consoleValues) {
-    for (const needle of relayPayloadNeedles) {
-      expect(value).not.toContain(needle)
-    }
+    expectNoRelayPayloadText([value], relayPayloadMarkers)
   }
-  await assertNoRelayPayloadPersistence(
-    page,
-    relayPayloadNeedles,
-    relayPayloadByteNeedles,
-  )
+  await assertNoRelayPayloadPersistence(page, relayPayloadMarkers)
 })

--- a/tests/e2e/persistence-inspector.ts
+++ b/tests/e2e/persistence-inspector.ts
@@ -174,13 +174,30 @@ export async function inspectPersistentSurfaces(
       )
       .sort((left, right) => left.name.localeCompare(right.name))
     for (const entry of databaseEntries) {
+      inspectString(entry.name, `indexedDB:${entry.name}:database-name`)
       const database = await openDatabase(entry.name)
       try {
         for (const storeName of Array.from(database.objectStoreNames).sort()) {
           const storeLocation = `indexedDB:${entry.name}/${storeName}`
           indexedDbStores.push(`${entry.name}/${storeName}`)
+          inspectString(storeName, `${storeLocation}:store-name`)
           const transaction = database.transaction(storeName, "readonly")
           const store = transaction.objectStore(storeName)
+          await inspectValue(
+            store.keyPath,
+            `${storeLocation}:key-path`,
+            new WeakSet(),
+          )
+          for (const indexName of Array.from(store.indexNames).sort()) {
+            const index = store.index(indexName)
+            const indexLocation = `${storeLocation}.indexes[${indexName}]`
+            inspectString(indexName, `${indexLocation}:name`)
+            await inspectValue(
+              index.keyPath,
+              `${indexLocation}:key-path`,
+              new WeakSet(),
+            )
+          }
           const [keys, values] = await Promise.all([
             requestResult(store.getAllKeys()),
             requestResult(store.getAll()),

--- a/tests/e2e/persistence-inspector.ts
+++ b/tests/e2e/persistence-inspector.ts
@@ -15,13 +15,15 @@ export interface PersistenceInspection {
   matches: PersistenceMatch[]
   indexedDbStores: string[]
   localStorageKeys: string[]
+  cookieKeys: string[]
   cacheKeys: string[]
 }
 
 /**
- * Recursively scans every IndexedDB plus CacheStorage metadata/body and local
- * storage. Text needles are also searched as UTF-8 bytes; explicit byte
- * needles catch typed arrays and other structured-clone binary values.
+ * Recursively scans every IndexedDB, CacheStorage metadata/body, local storage,
+ * and browser-context cookie (including HttpOnly). Text needles are also
+ * searched as UTF-8 bytes; explicit byte needles catch typed arrays and other
+ * structured-clone binary values.
  */
 export async function inspectPersistentSurfaces(
   page: Page,
@@ -32,7 +34,8 @@ export async function inspectPersistentSurfaces(
     text,
     bytes: bytes === undefined ? undefined : Array.from(bytes),
   }))
-  return page.evaluate(async (candidateNeedles) => {
+  const cookies = await page.context().cookies()
+  return page.evaluate(async ({ candidateNeedles, cookies }) => {
     interface Match {
       marker: string
       location: string
@@ -228,6 +231,18 @@ export async function inspectPersistentSurfaces(
       inspectString(localStorage.getItem(key) ?? "", `localStorage:${key}:value`)
     }
 
+    const cookieKeys: string[] = []
+    cookies.sort((left, right) =>
+      `${left.domain}:${left.path}:${left.name}`.localeCompare(
+        `${right.domain}:${right.path}:${right.name}`,
+      ),
+    )
+    for (const cookie of cookies) {
+      const cookieLocation = `cookies:${cookie.domain}${cookie.path}:${cookie.name}`
+      cookieKeys.push(`${cookie.domain}${cookie.path}:${cookie.name}`)
+      await inspectValue(cookie, cookieLocation, new WeakSet())
+    }
+
     const cacheKeys: string[] = []
     for (const cacheName of (await caches.keys()).sort()) {
       inspectString(cacheName, `CacheStorage:${cacheName}:name`)
@@ -268,7 +283,8 @@ export async function inspectPersistentSurfaces(
       ),
       indexedDbStores,
       localStorageKeys,
+      cookieKeys,
       cacheKeys: cacheKeys.sort(),
     }
-  }, serialized)
+  }, { candidateNeedles: serialized, cookies })
 }

--- a/tests/unit/relay-frames.test.ts
+++ b/tests/unit/relay-frames.test.ts
@@ -503,6 +503,49 @@ describe("relay capture session kind", () => {
     })
   })
 
+  it("reports message-count before decoding a malformed second OCM1 line", () => {
+    expect(parseRelayText(`${messagePayload()}\nOCM1:AA`)).toEqual({
+      ok: false,
+      code: "message-count",
+    })
+  })
+
+  it("reports message-count before decoding a malformed first OCM1 line", () => {
+    expect(parseRelayText(`OCM1:AA\n${messagePayload()}`)).toEqual({
+      ok: false,
+      code: "message-count",
+    })
+  })
+
+  it("reports kind-mismatch from prefixes before decoding a malformed OCF2 line", () => {
+    expect(parseRelayText(`${messagePayload()}\nOCF2:AA`)).toEqual({
+      ok: false,
+      code: "kind-mismatch",
+    })
+  })
+
+  it("reports frame-count before decoding an over-limit frame set", () => {
+    const lines = Array.from(
+      { length: PROTOCOL_MAX_FRAMES + 1 },
+      (_, index) => (index === PROTOCOL_MAX_FRAMES ? "OCF2:AA" : payload(0)),
+    )
+    expect(parseRelayText(lines.join("\n"))).toEqual({
+      ok: false,
+      code: "frame-count",
+    })
+  })
+
+  it("reports message-count for a large OCM1-prefixed paste without decoding it", () => {
+    const lines = Array.from(
+      { length: PROTOCOL_MAX_FRAMES },
+      () => "OCM1:AA",
+    )
+    expect(parseRelayText(lines.join("\n"))).toEqual({
+      ok: false,
+      code: "message-count",
+    })
+  })
+
   it("validates every pasted line before deciding whether valid kinds conflict", () => {
     const message = messagePayload()
     expect(

--- a/tests/unit/relay-frames.test.ts
+++ b/tests/unit/relay-frames.test.ts
@@ -546,7 +546,7 @@ describe("relay capture session kind", () => {
     })
   })
 
-  it("validates every pasted line before deciding whether valid kinds conflict", () => {
+  it("gives unknown prefixes precedence and decides allowed-prefix kind conflicts before decoding", () => {
     const message = messagePayload()
     expect(
       parseRelayText(`OCM1:AA\nhttps://example.invalid/`),
@@ -556,11 +556,11 @@ describe("relay capture session kind", () => {
     })
     expect(parseRelayText(`${message}\nOCF2:AA`)).toEqual({
       ok: false,
-      code: "invalid-frame",
+      code: "kind-mismatch",
     })
     expect(parseRelayText(`OCM1:AA\n${payload(0)}`)).toEqual({
       ok: false,
-      code: "invalid-message",
+      code: "kind-mismatch",
     })
     expect(
       parseRelayText(
@@ -568,7 +568,7 @@ describe("relay capture session kind", () => {
       ),
     ).toEqual({
       ok: false,
-      code: "outer-type",
+      code: "kind-mismatch",
     })
   })
 })


### PR DESCRIPTION
Two independent audits of the freshly merged OCM1 relay work (PR #49) each found things the
other did not. Every finding was re-verified against the tree before any code was written, and
one of my own candidate findings was withdrawn when the tests showed it was a deliberate design.

## What was wrong

**The prefix gate cited the wrong threat-model row.** `classifyRelayLine`'s comment described
T19's two-kind allowlist but cited **T21**, whose countermeasure column opens with *"Effectively
none"* — T21 is covert egress by a compromised offline device, not the row this code implements.
A reader following the citation landed on a threat the allowlist does not mitigate. The comment
also called itself *"the relay's entire allowlist"* while being only its prefix third:
`parseRelayFrameSet` enforces the OCF2 outer type and `parseRelayMessage` enforces OCM1 canonical
form.

**Paste cardinality was decided after the expensive work.** `parseRelayText` admitted the
OCF2-sized text budget and fully validated every line — CBOR decode, strict schema, canonical
re-encode — before checking whether there was more than one message. A paste of ~683 copies of a
311-character OCM1 fits that budget and ran ~683 full decodes on the UI thread before returning
the already-inevitable `message-count`.

**The two leakage oracles disagreed about what a payload is, and the request-side one was
weaker.** It never captured headers; it constrained query keys on only two special-cased paths;
and it searched a smaller needle set than the storage oracle sitting beside it. Those compose:
`GET /icons/icon-192.png?createdAt=1700000000000` was allowed *and* `1700000000000` was not in the
set the request loop searched. T19 names *"same-origin relay-payload-bearing request regression"*
as something this row is supposed to cover.

**The storage oracle collected IndexedDB database and store names and never searched them**, while
searching CacheStorage names, localStorage keys, and even cache header names. A store *named* from
a payload value was durable state that produced no match.

No live leak was found — relay values flow only through React state, QR rendering, and the
explicit clipboard action. What was broken is the guard meant to catch a future regression.

## Then the reviewers got past the fix, four more times

The widened oracle went to two reviewers who were asked to defeat it. They did:

- **Percent-encoding.** `URLSearchParams` writes the colon of `OCM1:` as `%3A`, so the marker was
  not a substring of the serialized URL. One reviewer extracted the functions and drove them until
  they printed `ORACLE MISS`.
- **Header-name case.** Chromium lower-cases header names; the markers keep their case, so the
  OCM1 `keyId` used as a header name matched nothing. Confirmed against a real request.
- **`Request.headers()` omits security headers, including `Cookie`** — documented in the installed
  Playwright 1.62 types. A marker in a cookie left the browser unseen, and the persistence oracle
  did not inspect cookies either.
- **Service-worker requests are emitted only on the `BrowserContext`.** With `page.on("request")`,
  a regression routing relay text through the service worker produced *no observation at all* and
  every request assertion vanished with it. Switching to `context.on("request")` immediately
  surfaced a real precache request that had never been observed.

Header normalization is applied at the header comparison only. Lower-casing the marker set would
have loosened the body and query checks — closing one hole by opening two.

Cookies are now treated as durable state, with a reason: a cookie can outlive the relay operation
and can be `HttpOnly`, which page JavaScript cannot see, so a page-side oracle is not sufficient.

## Behavior change, and its direction

Cardinality is now decided from prefixes alone, before anything is decoded. **No input changes
from accepted to rejected or the reverse** — only the error reported for input that was rejected
either way. For two or more `OCM1:`-prefixed lines where a later line is also malformed, the code
becomes `message-count` instead of that line's specific error. Safer: the rejection was
inevitable, and returning it before hundreds of decode/schema/re-encode operations bounds the work
by kind rather than by the much larger frame-text budget.

The case that pinned the old precedence was renamed, because its name — *"validates every pasted
line before deciding whether valid kinds conflict"* — stated the contract this inverts. The
specific codes those assertions used to pin remain covered for single-kind input, verified
independently before the rename.

## Deliberate designs left alone

An identical OCM1 is idempotent at the camera boundary and an error on paste — a camera sees one
QR many times, a pasted duplicate is a user mistake. `relayMessageEcLevel` goes Q → M → L and
never H. Both are pinned by named tests. I raised the first as a possible contradiction and
withdrew it after reading them.

## Verification

```
typecheck   exit 0
lint        0 errors, 17 warnings
test        59 files / 809 tests passed
build:prod  exit 0
test:e2e    28 passed against this checkout's dist, 1.2m
```

804 → 809 is five new unit cases for the ordering. Every widened sink was proven by injecting a
marker, watching the suite fail, and removing it.

Freshness: `protocol-docs` and `security-review` verifications passed; no unit was stamped,
because passing `verify` is necessary and not sufficient — their methods require a full refresh
that was not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)