### PR TITLE
ci: state the test worker count instead of inheriting the runner's

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -42,16 +42,16 @@ jobs:
         run: aube run lint
 
       - name: Unit tests
-        run: aube run test
+        run: aube run test -- --maxWorkers=2
 
       - name: Post-quantum known-answer tests
-        run: aube run test:pq-vectors
+        run: aube run test:pq-vectors -- --maxWorkers=2
 
       - name: Post-quantum integration tests
-        run: aube run test:pq
+        run: aube run test:pq -- --maxWorkers=2
 
       - name: Multipart QR tests
-        run: aube run test:qr-multipart
+        run: aube run test:qr-multipart -- --maxWorkers=2
 
       - name: Build production PWA
         run: aube run build:prod

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -68,16 +68,16 @@ jobs:
         run: aube run lint
 
       - name: Unit tests
-        run: aube run test
+        run: aube run test -- --maxWorkers=2
 
       - name: Post-quantum known-answer tests
-        run: aube run test:pq-vectors
+        run: aube run test:pq-vectors -- --maxWorkers=2
 
       - name: Post-quantum integration tests
-        run: aube run test:pq
+        run: aube run test:pq -- --maxWorkers=2
 
       - name: Multipart QR tests
-        run: aube run test:qr-multipart
+        run: aube run test:qr-multipart -- --maxWorkers=2
 
       - name: Build production PWA
         run: aube run build:prod


### PR DESCRIPTION
## What happened

A CI run on `dev` failed at
`tests/pq/worker-integration.test.ts > generates and regenerates maximum public keys without
returning seeds` with `AppError: ENCRYPTION_FAILED`.

## Why it is not a code regression

The same commit passed and failed in two runs two seconds apart:

```
failure   CI   1527067   2026-07-29T19:18:39Z
success   CI   1527067   2026-07-29T19:18:37Z
```

Same SHA, opposite outcomes. Five local runs of the suite — three bounded, two unbounded — were
green at 809 tests. This host has 16 cores and 15 GB; the runner has far less, which is why the
condition does not reproduce here.

The failing case is maximum-profile ML-KEM-1024 + ML-DSA-87 identity generation, the heaviest
operation in the suite.

## Why the error message could not help

`ENCRYPTION_FAILED` is `fallbackCode`'s catch-all for `generateIdentityKeys`
(`src/workers/pq-crypto.worker.ts:523-526`). The worker sanitizes errors at its boundary
deliberately — its own comment says so — so resource exhaustion, a timeout, and a real defect all
surface as the same code.

**That sanitizing is correct and is not touched here.** It does mean this path's CI failures carry
no diagnostic information, which is a real cost worth knowing about rather than fixing by leaking
error detail across a boundary that exists to stop exactly that.

## The change

Every CI test invocation now states `--maxWorkers=2` rather than inheriting whatever the runner
infers.

This is the repository's own discipline, applied to the one place that had escaped it: worker
counts are part of a test result, and an unbounded run manufactures failures indistinguishable
from regressions. Stating the number also means a runner-fleet change cannot silently alter the
conditions a green build was measured under.

**Claimed narrowly:** this makes the condition explicit and stable and lowers peak concurrency. It
is not proven to be the cause, because the cause is not reproducible here and the error code
hides it.

Verified that `--` actually reaches vitest rather than being swallowed by `aube`: an unknown flag
fails with `CACError: Unknown option` from vitest's own parser. A pass-through that silently did
nothing would have made this change theatre.

## A larger finding, deliberately not acted on here

`aube run test` already runs the three suites CI then runs again as named steps. From
`vitest.config.ts`, the `node` project includes:

```
"tests/pq/**/*.test.ts",
"tests/pq-vectors/**/*.test.ts",
"tests/qr-multipart/**/*.test.ts",
```

So `test:pq-vectors`, `test:pq` and `test:qr-multipart` re-run work `test` has already done, and
**every CI run executes the heaviest suites twice.** Dropping the three named steps would halve
that pressure and is plausibly the better fix.

It is not in this change because the named steps buy something real — a failing step names its
suite in the CI UI — and trading that away is the owner's call, not a side effect of bounding
workers. Vitest already names the failing file, so the trade looks favourable, but it should be
decided on its own.

## Verification

```
aube run test -- --maxWorkers=2   →  59 files / 809 tests passed
```

Workflow files only; no source, test, or configuration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)