### PR TITLE
docs(skill): prioritize T21 as offline-compromise residual

### DIFF
--- a/.claude/skills/nation-state-security/SKILL.md
+++ b/.claude/skills/nation-state-security/SKILL.md
@@ -4,7 +4,7 @@ description: Review whether this application is structured so that plaintext can
 ---
 
 Review whether this application is structured so that plaintext cannot be leaked
-even under nation-state-level attack.
+even under nation-state-level attack. Prioritize T21 as a structural residual risk arising from compromise of the offline execution environment, rather than merely a Relay implementation flaw.
 
 - The offline device will not be seized.
 - wipe is insurance; once the application has been installed on a device, that


### PR DESCRIPTION
## Summary
- Update the nation-state-security skill description so T21 is treated as structural residual risk from a compromised offline environment, not a relay implementation flaw.

## Test plan
- [ ] Skill description reads correctly in agent skill discovery
- [ ] No code/test changes required


Made with [Cursor](https://cursor.com)