### PR TITLE
test: consolidate duplicated test helpers and drop dead test surface

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -15,7 +15,6 @@ import {
 } from "@zxing/library"
 
 export const AES_ALGORITHM_LABEL = "Symmetric-key AES-256-GCM"
-export const PQ_ALGORITHM_LABEL = /^Post-quantum ML-KEM-1024 \+ AES-256-GCM$/
 export const SIGNED_PQ_ALGORITHM_LABEL = /Signed post-quantum/
 const ONLINE_GATE_TIMEOUT_MS = 30_000
 const expectOnline = expect.configure({ timeout: ONLINE_GATE_TIMEOUT_MS })
@@ -336,11 +335,10 @@ export async function encryptWithStoredKey(
   args: {
     keyName: string
     plaintext: string
-    algorithmLabel?: string | RegExp
   },
 ): Promise<{ payload: string }> {
   await goToOfflinePage(page, "/encrypt")
-  await chooseOption(page, "Cryptographic algorithm", args.algorithmLabel ?? AES_ALGORITHM_LABEL)
+  await chooseOption(page, "Cryptographic algorithm", AES_ALGORITHM_LABEL)
   await chooseOption(page, "Key", args.keyName)
   await page.getByLabel("Plaintext", { exact: true }).fill(args.plaintext)
   await page.getByRole("button", { name: "Encrypt", exact: true }).click()

--- a/tests/helpers/deferred.ts
+++ b/tests/helpers/deferred.ts
@@ -1,0 +1,15 @@
+export interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+}
+
+export function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/tests/helpers/memory-storage.ts
+++ b/tests/helpers/memory-storage.ts
@@ -1,0 +1,27 @@
+export class MemoryStorage implements Storage {
+  #values = new Map<string, string>()
+
+  get length(): number {
+    return this.#values.size
+  }
+
+  clear(): void {
+    this.#values.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.#values.get(key) ?? null
+  }
+
+  key(index: number): string | null {
+    return [...this.#values.keys()][index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.#values.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.#values.set(key, value)
+  }
+}

--- a/tests/integration/best-effort-reset.test.ts
+++ b/tests/integration/best-effort-reset.test.ts
@@ -29,34 +29,7 @@ import {
   STORE_PREFERENCES,
 } from "@/storage/database"
 import { OFFLINE_ACK_PENDING_KEY } from "@/app/offline-ack-marker"
-
-class MemoryStorage implements Storage {
-  readonly values = new Map<string, string>()
-
-  get length(): number {
-    return this.values.size
-  }
-
-  clear(): void {
-    this.values.clear()
-  }
-
-  getItem(key: string): string | null {
-    return this.values.get(key) ?? null
-  }
-
-  key(index: number): string | null {
-    return Array.from(this.values.keys())[index] ?? null
-  }
-
-  removeItem(key: string): void {
-    this.values.delete(key)
-  }
-
-  setItem(key: string, value: string): void {
-    this.values.set(key, value)
-  }
-}
+import { MemoryStorage } from "../helpers/memory-storage"
 
 function dependencies(
   overrides: Partial<BestEffortResetDependencies> = {},
@@ -212,7 +185,9 @@ describe("best-effort local reset", () => {
     storage.setItem("oc-sensitive", "value")
     storage.setItem("unrelated", "keep")
     clearOcLocalStorage(storage)
-    expect(Array.from(storage.values.entries())).toEqual([["unrelated", "keep"]])
+    expect(storage.length).toBe(1)
+    expect(storage.key(0)).toBe("unrelated")
+    expect(storage.getItem("unrelated")).toBe("keep")
   })
 
   it("re-establishes the real marker after online wipe but not user reset", async () => {
@@ -228,14 +203,16 @@ describe("best-effort local reset", () => {
       { reason: "online-detected", resetChurnMb: 0 },
       resetDependencies,
     )
-    expect(Array.from(storage.values.entries())).toEqual([[OFFLINE_ACK_PENDING_KEY, "1"]])
+    expect(storage.length).toBe(1)
+    expect(storage.key(0)).toBe(OFFLINE_ACK_PENDING_KEY)
+    expect(storage.getItem(OFFLINE_ACK_PENDING_KEY)).toBe("1")
 
     storage.setItem("oc-theme", "light")
     await bestEffortLocalReset(
       { reason: "user-requested", resetChurnMb: 0 },
       resetDependencies,
     )
-    expect(Array.from(storage.values.entries())).toEqual([])
+    expect(storage.length).toBe(0)
   })
 
   it("performs the real logical DB deletion and absence verification", async () => {

--- a/tests/ui/animated-qr-frames.test.tsx
+++ b/tests/ui/animated-qr-frames.test.tsx
@@ -21,6 +21,7 @@ import { useFrameSplit } from "@/hooks/use-frame-split"
 import { encodeFrameToPayload } from "@/qr/payload-v2"
 import type { QrFrameV2 } from "@/schemas/domain"
 import { env } from "@/schemas/env-schema"
+import { deferred } from "../helpers/deferred"
 import {
   exportQrFramePayloads,
   qrPngBlob,
@@ -51,16 +52,6 @@ function frame(
     totalByteLength,
     chunk: Uint8Array.of(frameIndex),
   }
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
 }
 
 type FullscreenShape = "transport" | "arbitrary" | "none"

--- a/tests/ui/auto-clear.test.tsx
+++ b/tests/ui/auto-clear.test.tsx
@@ -1,9 +1,16 @@
-import "./helpers/module-mocks"
 import { act, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { env } from "@/schemas/env-schema"
-import { mockWebAssemblyProbe, probeWebAssemblyRuntime } from "./helpers/fakes"
+import { deferred } from "../helpers/deferred"
+import * as fakes from "./helpers/fakes"
 import { resetUi } from "./helpers/render-app"
+
+vi.mock("@/lib/feature-detect", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/feature-detect")>()),
+  detectFeatures: fakes.detectFeatures,
+  probeWebAssemblyRuntime: fakes.probeWebAssemblyRuntime,
+  webAssemblyRuntimeSupport: fakes.webAssemblyRuntimeSupport,
+}))
 
 function setVisibility(value: DocumentVisibilityState): void {
   Object.defineProperty(document, "visibilityState", {
@@ -12,18 +19,10 @@ function setVisibility(value: DocumentVisibilityState): void {
   })
 }
 
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise
-  })
-  return { promise, resolve }
-}
-
 describe("useAutoClear fixed deadline semantics", () => {
   beforeEach(() => {
     resetUi()
-    mockWebAssemblyProbe(true)
+    fakes.mockWebAssemblyProbe(true)
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-07-21T00:00:00Z"))
     setVisibility("visible")
@@ -76,7 +75,7 @@ describe("useAutoClear fixed deadline semantics", () => {
   })
 
   it("uses env.autoClearFallbackSeconds when the WebAssembly runtime probe fails", async () => {
-    mockWebAssemblyProbe(false)
+    fakes.mockWebAssemblyProbe(false)
     const { useAutoClear } = await import("@/hooks/use-auto-clear")
     const onClear = vi.fn()
     function Harness() {
@@ -85,7 +84,7 @@ describe("useAutoClear fixed deadline semantics", () => {
     }
     render(<Harness />)
     await act(async () => undefined)
-    expect(probeWebAssemblyRuntime).toHaveBeenCalled()
+    expect(fakes.probeWebAssemblyRuntime).toHaveBeenCalled()
 
     act(() => {
       setVisibility("hidden")
@@ -101,7 +100,7 @@ describe("useAutoClear fixed deadline semantics", () => {
     const runtimeProbe = deferred<boolean>()
     runtimeProbe.resolve(false)
     await runtimeProbe.promise
-    mockWebAssemblyProbe(runtimeProbe.promise)
+    fakes.mockWebAssemblyProbe(runtimeProbe.promise)
     setVisibility("hidden")
     const { useAutoClear } = await import("@/hooks/use-auto-clear")
     const onClear = vi.fn()
@@ -125,7 +124,7 @@ describe("useAutoClear fixed deadline semantics", () => {
 
   it("keeps a fail-secure pending deadline and applies fallback only next time", async () => {
     const runtimeProbe = deferred<boolean>()
-    mockWebAssemblyProbe(runtimeProbe.promise)
+    fakes.mockWebAssemblyProbe(runtimeProbe.promise)
     const { useAutoClear } = await import("@/hooks/use-auto-clear")
     const onClear = vi.fn()
     function Harness() {

--- a/tests/ui/boot-app.test.tsx
+++ b/tests/ui/boot-app.test.tsx
@@ -205,6 +205,9 @@ describe("App boot gate", () => {
     await renderApp("/encrypt", { bootController: controller })
 
     expect(await screen.findByText("RESET_FAILED")).toBeInTheDocument()
+    // Naming the steps that failed is the only actionable detail this terminal
+    // screen can offer; the settings-originated reset reports into it too.
+    expect(screen.getByText("database-verification")).toBeInTheDocument()
     expect(
       screen.queryByText(translate("en", "relay.card.title")),
     ).not.toBeInTheDocument()

--- a/tests/ui/boot-controller.test.tsx
+++ b/tests/ui/boot-controller.test.tsx
@@ -18,28 +18,7 @@ import {
   recordReceipt,
   type ReceiptSubject,
 } from "@/features/receipt-cache"
-
-class MemoryStorage implements Storage {
-  readonly values = new Map<string, string>()
-  get length(): number {
-    return this.values.size
-  }
-  clear(): void {
-    this.values.clear()
-  }
-  getItem(key: string): string | null {
-    return this.values.get(key) ?? null
-  }
-  key(index: number): string | null {
-    return Array.from(this.values.keys())[index] ?? null
-  }
-  removeItem(key: string): void {
-    this.values.delete(key)
-  }
-  setItem(key: string, value: string): void {
-    this.values.set(key, String(value))
-  }
-}
+import { MemoryStorage } from "../helpers/memory-storage"
 
 const localStorage = new MemoryStorage()
 Object.defineProperty(window, "localStorage", {

--- a/tests/ui/decrypt-page.test.tsx
+++ b/tests/ui/decrypt-page.test.tsx
@@ -12,6 +12,7 @@ import type {
   PqPublicBundleRecord,
 } from "@/schemas/domain"
 import { env } from "@/schemas/env-schema"
+import { deferred } from "../helpers/deferred"
 import {
   deferNextMultipartAdd,
   decryptWithAesKey,
@@ -38,16 +39,6 @@ const fakePqMessageIdHex = Array.from(fakePqMessageId, (byte) =>
   byte.toString(16).padStart(2, "0"),
 ).join("")
 let clearRealReceipts: (() => void) | undefined
-
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, reject, resolve }
-}
 
 function expectedFakePayloadHash(payload: string): string {
   return new TextEncoder()

--- a/tests/ui/encrypt-page.test.tsx
+++ b/tests/ui/encrypt-page.test.tsx
@@ -14,6 +14,7 @@ import type {
   PqPublicBundleRecord,
 } from "@/schemas/domain"
 import { env } from "@/schemas/env-schema"
+import { deferred } from "../helpers/deferred"
 import {
   encryptWithAesKey,
   encryptPq,
@@ -36,16 +37,6 @@ async function chooseSelectOption(
 ) {
   await user.click(await screen.findByLabelText(label))
   await user.click(await screen.findByRole("option", { name: option }))
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, reject, resolve }
 }
 
 describe("encrypt page v2", () => {

--- a/tests/ui/helpers/fakes.ts
+++ b/tests/ui/helpers/fakes.ts
@@ -474,14 +474,11 @@ export const readerModuleState = vi.fn<
 >(() => "ready")
 export const warmQrReader = vi.fn<() => Promise<void>>(() => Promise.resolve())
 let scanTextCallback: ((payload: string) => void) | null = null
-let scanErrorCallback:
-  | ((error: FakeAppError, failureState: FakeCameraFailureState) => void)
-  | null = null
 export const startQrScan = vi.fn(
   async (
     _video: HTMLVideoElement,
     onText: (payload: string) => void,
-    onError: (error: FakeAppError, failureState: FakeCameraFailureState) => void,
+    _onError: (error: FakeAppError, failureState: FakeCameraFailureState) => void,
     _options?: {
       once?: boolean
       signal?: AbortSignal
@@ -489,18 +486,11 @@ export const startQrScan = vi.fn(
   ): Promise<{ stop: () => void }> => {
     void _options
     scanTextCallback = onText
-    scanErrorCallback = onError
     return { stop: scannerStop }
   },
 )
 export function emitScannedPayload(payload: string): void {
   scanTextCallback?.(payload)
-}
-export function emitScanError(
-  code: ErrorCode,
-  failureState: FakeCameraFailureState = "failed",
-): void {
-  scanErrorCallback?.(new FakeAppError(code), failureState)
 }
 
 export const disposePqClient = vi.fn()
@@ -1009,7 +999,6 @@ export function resetFakes(): void {
   lastDsaEnvelope = null
   fakePqDecrypt.kind = "signed-valid"
   scanTextCallback = null
-  scanErrorCallback = null
   nextMultipartAddGate = null
   decryptPqMessage.mockImplementation(defaultDecryptPqMessage)
   findBundleBySigningKeyId.mockImplementation(defaultFindBundleBySigningKeyId)

--- a/tests/ui/helpers/render-app.tsx
+++ b/tests/ui/helpers/render-app.tsx
@@ -3,39 +3,12 @@ import { createElement, type ComponentProps } from "react"
 import { resetFakes } from "./fakes"
 import { setTestOnlineStatus } from "./network"
 import { clearAckPending } from "@/app/offline-ack-marker"
+import { MemoryStorage } from "../../helpers/memory-storage"
 
 type AppComponent = typeof import("@/app/App").App
 let appComponent: AppComponent | null = null
 
-class MemoryLocalStorage implements Storage {
-  readonly #values = new Map<string, string>()
-
-  get length(): number {
-    return this.#values.size
-  }
-
-  clear(): void {
-    this.#values.clear()
-  }
-
-  getItem(key: string): string | null {
-    return this.#values.get(key) ?? null
-  }
-
-  key(index: number): string | null {
-    return Array.from(this.#values.keys())[index] ?? null
-  }
-
-  removeItem(key: string): void {
-    this.#values.delete(key)
-  }
-
-  setItem(key: string, value: string): void {
-    this.#values.set(key, String(value))
-  }
-}
-
-export const memoryLocalStorage = new MemoryLocalStorage()
+export const memoryLocalStorage = new MemoryStorage()
 Object.defineProperty(window, "localStorage", {
   configurable: true,
   value: memoryLocalStorage,

--- a/tests/ui/key-list-page.test.tsx
+++ b/tests/ui/key-list-page.test.tsx
@@ -11,6 +11,7 @@ import { LanguageProvider } from "@/i18n"
 import { translate } from "@/i18n/messages"
 import { decodeFramePayload } from "@/qr/payload-v2"
 import type { PostQuantumIdentity, PqPublicBundleRecord } from "@/schemas/domain"
+import { deferred } from "../helpers/deferred"
 import {
   confirmBundleFingerprint,
   deleteBundle,
@@ -54,14 +55,6 @@ function expectSingleAlertCancelWithoutClose(dialog: HTMLElement): void {
     within(dialog).queryByRole("button", { name: "Close" }),
   ).toBeNull()
   expect(dialog.querySelector("svg.lucide-x")).toBeNull()
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise
-  })
-  return { promise, resolve }
 }
 
 async function renderKeyList(): Promise<void> {

--- a/tests/ui/keys-settings.test.tsx
+++ b/tests/ui/keys-settings.test.tsx
@@ -17,6 +17,7 @@ import type {
   PublicIdentityBundleV2,
 } from "@/schemas/domain"
 import { env } from "@/schemas/env-schema"
+import { deferred } from "../helpers/deferred"
 import {
   armMaintenanceToken,
   clearAllIdentities,
@@ -41,14 +42,6 @@ import { renderApp, resetUi } from "./helpers/render-app"
 
 function en(key: Parameters<typeof translate>[1]): string {
   return translate("en", key)
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise
-  })
-  return { promise, resolve }
 }
 
 function expectSingleAlertCancelWithoutClose(dialog: HTMLElement): void {

--- a/tests/ui/multipart-scan.test.tsx
+++ b/tests/ui/multipart-scan.test.tsx
@@ -6,6 +6,7 @@ import { QrScannerPanel } from "@/components/qr-scanner-panel"
 import { AppError, messageFor } from "@/crypto/errors"
 import { MultipartScanSession } from "@/features/multipart-scan-session"
 import type { TransferState } from "@/qr/multipart/transfer-state"
+import { deferred } from "../helpers/deferred"
 import {
   emitScannedPayload,
   multipartPayload,
@@ -13,17 +14,6 @@ import {
   startQrScan,
 } from "./helpers/fakes"
 import { resetUi } from "./helpers/render-app"
-
-function deferred<T>(): {
-  promise: Promise<T>
-  resolve: (value: T) => void
-} {
-  let resolve: (value: T) => void = () => undefined
-  const promise = new Promise<T>((settle) => {
-    resolve = settle
-  })
-  return { promise, resolve }
-}
 
 function scanner(
   session: MultipartScanSession,

--- a/tests/ui/online-relay.test.tsx
+++ b/tests/ui/online-relay.test.tsx
@@ -13,6 +13,7 @@ import {
   OCM1_MESSAGE_33,
   OCM1_MESSAGE_44,
 } from "../fixtures/relay-v1"
+import { deferred, type Deferred } from "../helpers/deferred"
 
 const scanStart = vi.hoisted(() => vi.fn())
 const scanStop = vi.hoisted(() => vi.fn())
@@ -91,22 +92,6 @@ async function startCapture(user: ReturnType<typeof userEvent.setup>) {
     }),
   )
   await waitFor(() => expect(scanText).not.toBeNull())
-}
-
-interface Deferred<T> {
-  promise: Promise<T>
-  resolve(value: T): void
-  reject(reason?: unknown): void
-}
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
 }
 
 function playbackPayloads(marker: number): readonly [string, string] {

--- a/tests/ui/qr-scanner.test.tsx
+++ b/tests/ui/qr-scanner.test.tsx
@@ -22,6 +22,7 @@ import { MultipartScanSession } from "@/features/multipart-scan-session"
 import { translate } from "@/i18n/messages"
 import type { QrScanHandle } from "@/qr/decode"
 import type { TransferState } from "@/qr/multipart/transfer-state"
+import { deferred } from "../helpers/deferred"
 import {
   emitScannedPayload,
   multipartPayload,
@@ -38,20 +39,6 @@ function setVisibility(state: DocumentVisibilityState): void {
     configurable: true,
     value: state,
   })
-}
-
-function deferred<T>(): {
-  promise: Promise<T>
-  resolve: (value: T) => void
-  reject: (reason: unknown) => void
-} {
-  let resolve: (value: T) => void = () => undefined
-  let reject: (reason: unknown) => void = () => undefined
-  const promise = new Promise<T>((settle, fail) => {
-    resolve = settle
-    reject = fail
-  })
-  return { promise, resolve, reject }
 }
 
 describe("QrScannerPanel single scan and camera lifecycle", () => {

--- a/tests/ui/use-compatibility-mode.test.tsx
+++ b/tests/ui/use-compatibility-mode.test.tsx
@@ -6,22 +6,7 @@ import {
   DEFAULT_GENERATED_DISPLAY_PAIR,
   type Preferences,
 } from "@/schemas/domain"
-
-interface Deferred<T> {
-  promise: Promise<T>
-  resolve(value: T): void
-  reject(reason?: unknown): void
-}
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
+import { deferred } from "../helpers/deferred"
 
 describe("useCompatibilityMode", () => {
   it("commits while active", async () => {

--- a/tests/unit/multipart-scan-session.test.ts
+++ b/tests/unit/multipart-scan-session.test.ts
@@ -3,22 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import { MultipartScanSession } from "@/features/multipart-scan-session"
 import { TransferAssembler } from "@/qr/multipart/assemble"
 import type { TransferState } from "@/qr/multipart/transfer-state"
-
-interface Deferred<T> {
-  promise: Promise<T>
-  resolve(value: T): void
-  reject(reason?: unknown): void
-}
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
+import { deferred } from "../helpers/deferred"
 
 async function flushMicrotasks(): Promise<void> {
   for (let index = 0; index < 12; index += 1) await Promise.resolve()

--- a/tests/unit/qr-scanner.test.ts
+++ b/tests/unit/qr-scanner.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { deferred } from "../helpers/deferred"
 
 const nativeWebAssembly = WebAssembly
 
@@ -17,22 +18,6 @@ vi.mock("zxing-wasm/reader", () => ({
 vi.mock("zxing-wasm/reader/zxing_reader.wasm?url", () => ({
   default: "/assets/zxing_reader-test-hash.wasm",
 }))
-
-interface Deferred<T> {
-  promise: Promise<T>
-  resolve(value: T): void
-  reject(reason?: unknown): void
-}
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
 
 class FakeTrack extends EventTarget {
   readonly kind = "video"

--- a/tests/unit/relay-frames.test.ts
+++ b/tests/unit/relay-frames.test.ts
@@ -298,11 +298,6 @@ function messagePayload(plaintextBytes = 32): string {
   return encodeEnvelopeToPayload(messageEnvelope(plaintextBytes))
 }
 
-// Production-generated and parser-pinned in this node environment.
-function symmetricKeyPayload(): string {
-  return OCK1_SYMMETRIC_KEY
-}
-
 const relayEncoder = new Encoder({ useRecords: false, tagUint8Array: false })
 
 // Same fields, different CBOR map key order. decodePayload accepts it because
@@ -378,7 +373,7 @@ describe("relay message acceptance", () => {
 
 describe("relay acceptance boundary", () => {
   const forbidden = () => [
-    ["canonical OCK1 symmetric key", symmetricKeyPayload()],
+    ["canonical OCK1 symmetric key", OCK1_SYMMETRIC_KEY],
     ["OCP1 public key", "OCP1:AA"],
     ["OCB1 reserved backup", "OCB1:AA"],
     ["OCM2 pq message", "OCM2:AA"],


### PR DESCRIPTION
Follow-up to #58, closing the last two items of the `/artful-simplicity` audit
remediation. Test files only — no production code changes.

## 1. Test-helper consolidation (the item #58 deliberately deferred)

The audit found the same helper re-declared across the suite. Consolidated:

- **`deferred<T>()` — 12 copies → one** (`tests/helpers/deferred.ts`). All twelve
  local versions were read before deletion. They differed only in incidentals:
  omitting the unused `reject` field, typing `resolve` as `T` instead of
  `T | PromiseLike<T>`, requiring rather than optional-ing the rejection reason,
  definite assignment vs. no-op initialisers, and key order. None had extra
  fields, a settled flag, cancellation, or different settlement semantics, so
  none needed to keep its own.
- **In-memory `Storage` — 3 copies → one** (`tests/helpers/memory-storage.ts`).
  `render-app.tsx` keeps exporting the `memoryLocalStorage` singleton that the
  UI suites and `resetUi()` depend on. One caller
  (`best-effort-reset.test.ts`) reached into the private `values` map; that
  access is gone and the same three properties — cardinality, insertion-order
  key, stored value — are now asserted through the real `Storage` surface
  (`length`, `key(0)`, `getItem`), so the test still covers what it covered.

## 2. Dead test surface removed

`emitScanError` (no importer — and the callback storage it fed, which became
unreachable with it; `startQrScan` keeps its parameter and signature),
`PQ_ALGORITHM_LABEL` (no importer; the adjacent `SIGNED_PQ_ALGORITHM_LABEL` is
used and stays), the `algorithmLabel` option on the e2e encrypt helper that no
caller ever passed, and a function in `relay-frames.test.ts` that wrapped a
constant and added nothing.

`auto-clear.test.tsx` pulled in the 25-module blanket mock to substitute exactly
one module; it now mocks only `@/lib/feature-detect`. That narrowing is
deliberately limited to this one suite — `module-mocks.ts` itself is untouched.

## 3. One assertion that missed the #58 push

`tests/ui/boot-app.test.tsx` now pins the failed steps rendered on the terminal
reset screen. That screen gained the list during #58's review round, but the
commit landed after the branch was pushed, so it never reached that PR.

## Verification

```
make check   typecheck 0 · lint 0 errors (17 pre-existing warnings) · 830 tests / 56 files
make e2e     28 passed
```

Test count is identical to `dev` (830) by design: this removes helper surface,
not test cases. `protocol-docs` is the only freshness unit naming a touched file
(`relay-frames.test.ts`, where a constant was inlined); its verify was re-run and
its `last_checked` is already current, so no stamp changed.

One process note worth recording: the delegated run first reported failures that
turned out to be host CPU contention from a concurrent e2e run of mine, not the
change. The numbers above are from an independent re-run on a quiet machine
after verifying each consolidation claim by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
