### PR TITLE
Give four contradicted contracts a single answer

### DIFF
--- a/docs/spec/boot-and-reset-v2.md
+++ b/docs/spec/boot-and-reset-v2.md
@@ -146,10 +146,11 @@ offline-confirmed -- display online re-commit --> probing (at most once)
    the Vault key record** (crypto-shredding; overwriting the bytes of a
    non-extractable `CryptoKey` is impossible and is not claimed).
 6. Delete all DBs (including `pqIdentities`/`pqPublicBundles`) + all `oc-*`
-   localStorage keys. This includes the UI language preference (`oc-lang`) and
-   the last online tab (`oc-online-tab`); after a wipe or full reset the UI
-   language reverts to the English default and the online gate's tab preference
-   reverts to the install screen.
+   localStorage keys. This includes the UI language (`oc-lang`), theme
+   (`oc-theme`), and last online tab (`oc-online-tab`) preferences; after a wipe
+   or full reset, the language reverts to English, the theme reverts to the
+   `system` default, and the online gate's tab preference reverts to the install
+   screen.
    Only in the `online-detected` case, re-set `oc-offline-ack-pending="1"`
    after the deletion and before publishing `wiped`. In the `user-requested`
    case it is not re-set.

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -11,6 +11,7 @@ import type { FeatureSupport } from "@/lib/feature-detect"
 import { DisplayGateProvider } from "@/app/display-gate"
 import { PwaOfflineReady, type UseRegisterSwHook } from "@/components/pwa-offline-ready"
 import { Toaster } from "@/components/ui/sonner"
+import { OC_LOCAL_STORAGE_CLEARED_EVENT } from "@/storage/reset-events"
 
 export type Theme = "light" | "dark" | "system"
 
@@ -21,9 +22,11 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
+export const THEME_STORAGE_KEY = "oc-theme"
+
 function storedTheme(): Theme {
   try {
-    const value = window.localStorage.getItem("oc-theme")
+    const value = window.localStorage.getItem(THEME_STORAGE_KEY)
     return value === "light" || value === "dark" || value === "system" ? value : "system"
   } catch {
     return "system"
@@ -44,7 +47,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setTheme = useCallback((nextTheme: Theme) => {
     try {
-      window.localStorage.setItem("oc-theme", nextTheme)
+      window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme)
     } catch {
       // Theme persistence is best-effort; rendering must survive denied storage.
     }
@@ -52,8 +55,24 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, [])
 
   useEffect(() => {
+    const resetToSystem = () => setThemeState("system")
+    const handlePeerStorageReset = (event: StorageEvent) => {
+      if (event.key === THEME_STORAGE_KEY && event.newValue === null) {
+        resetToSystem()
+      }
+    }
+
+    window.addEventListener(OC_LOCAL_STORAGE_CLEARED_EVENT, resetToSystem)
+    window.addEventListener("storage", handlePeerStorageReset)
+    return () => {
+      window.removeEventListener(OC_LOCAL_STORAGE_CLEARED_EVENT, resetToSystem)
+      window.removeEventListener("storage", handlePeerStorageReset)
+    }
+  }, [])
+
+  useEffect(() => {
     try {
-      window.localStorage.setItem("oc-theme", theme)
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme)
     } catch {
       // Keep the in-memory theme when persistence is unavailable.
     }

--- a/src/components/qr-scanner-panel.tsx
+++ b/src/components/qr-scanner-panel.tsx
@@ -16,6 +16,7 @@ import {
   type QrScanHandle,
 } from "@/qr/decode"
 import type { TransferState } from "@/qr/multipart/transfer-state"
+import { QR_PREFIX_V2 } from "@/qr/payload-v2"
 import {
   deliveryError,
   localized,
@@ -272,7 +273,7 @@ export function QrScannerPanel(props: QrScannerPanelProps) {
         return
       }
 
-      if (!payload.startsWith("OCF2:")) {
+      if (!payload.startsWith(QR_PREFIX_V2.frame)) {
         setError(
           localized("scanner.mismatch", {
             actual: t("scanner.payloadLabel.foreign"),

--- a/src/features/presentation.ts
+++ b/src/features/presentation.ts
@@ -2,7 +2,10 @@ import { translate, type Language } from "@/i18n/messages"
 import { QR_PREFIX_V2 } from "@/qr/payload-v2"
 import type { UiAlgorithm } from "@/schemas/domain"
 
-const QR_CRYPT_PREFIXES = Object.values(QR_PREFIX_V2)
+// OCB2 is reserved and rejected by every decoder; the display side must not call it valid.
+const QR_CRYPT_PREFIXES = Object.entries(QR_PREFIX_V2)
+  .filter(([kind]) => kind !== "encrypted-seed-backup")
+  .map(([, prefix]) => prefix)
 
 export const ALGORITHM_LABELS: Record<
   Language,

--- a/tests/ui/encrypt-page.test.tsx
+++ b/tests/ui/encrypt-page.test.tsx
@@ -896,7 +896,6 @@ describe("encrypt page v2", () => {
         screen.queryByRole("dialog", { name: "Encryption complete" }),
       ).not.toBeInTheDocument()
     })
-    expect(screen.queryByText(/^OCM1:/)).not.toBeInTheDocument()
     expect(screen.queryByText(/^OCA2:/)).not.toBeInTheDocument()
   })
 

--- a/tests/ui/theme-reset.test.tsx
+++ b/tests/ui/theme-reset.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen, act } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { OC_LOCAL_STORAGE_CLEARED_EVENT } from "@/storage/reset-events"
+import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from "@/app/providers"
+import { memoryLocalStorage } from "./helpers/render-app"
+
+vi.mock("virtual:pwa-register/react", () => ({
+  useRegisterSW: () => ({ offlineReady: [false, () => undefined] }),
+}))
+vi.mock("@/hooks/use-register-sw", () => ({
+  useDefaultRegisterSW: () => ({ offlineReady: [false, () => undefined] }),
+}))
+
+function ThemeProbe() {
+  const { theme } = useTheme()
+  return <span data-testid="theme">{theme}</span>
+}
+
+function renderTheme() {
+  render(
+    <ThemeProvider>
+      <ThemeProbe />
+    </ThemeProvider>,
+  )
+}
+
+describe("ThemeProvider reset contract", () => {
+  beforeEach(() => {
+    memoryLocalStorage.clear()
+    document.documentElement.classList.remove("dark")
+  })
+  afterEach(cleanup)
+
+  it("returns mounted state to the system default when oc-* keys are cleared", () => {
+    memoryLocalStorage.setItem(THEME_STORAGE_KEY, "dark")
+    renderTheme()
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark")
+
+    act(() => {
+      memoryLocalStorage.removeItem(THEME_STORAGE_KEY)
+      window.dispatchEvent(new Event(OC_LOCAL_STORAGE_CLEARED_EVENT))
+    })
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("system")
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+    expect(memoryLocalStorage.getItem(THEME_STORAGE_KEY)).toBe("system")
+  })
+
+  it("returns a mounted peer tab to the system default when its key is removed", () => {
+    memoryLocalStorage.setItem(THEME_STORAGE_KEY, "dark")
+    renderTheme()
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: THEME_STORAGE_KEY,
+          oldValue: "dark",
+          newValue: null,
+        }),
+      )
+    })
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("system")
+  })
+
+  it("ignores a peer write that sets a value", () => {
+    memoryLocalStorage.setItem(THEME_STORAGE_KEY, "dark")
+    renderTheme()
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: THEME_STORAGE_KEY,
+          oldValue: "dark",
+          newValue: "light",
+        }),
+      )
+    })
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark")
+  })
+
+  it("ignores the removal of an unrelated key", () => {
+    memoryLocalStorage.setItem(THEME_STORAGE_KEY, "dark")
+    renderTheme()
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "oc-lang",
+          oldValue: "ja",
+          newValue: null,
+        }),
+      )
+    })
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark")
+  })
+})

--- a/tests/unit/contract-smoke.test.ts
+++ b/tests/unit/contract-smoke.test.ts
@@ -71,9 +71,6 @@ describe("contract smoke", () => {
         "Invalid environment variables",
       )
     }
-    expect(() => parseAppEnv({ VITE_DEFAULT_PQ_PROFILE: "balanced" })).toThrow(
-      "Invalid environment variables",
-    )
   })
 
   it("omits retired post-quantum preferences from the parsed environment", () => {

--- a/tests/unit/presentation.test.ts
+++ b/tests/unit/presentation.test.ts
@@ -21,9 +21,11 @@ describe("presentation formatting", () => {
   })
 
   it("recognizes only active v2 prefixes", () => {
-    for (const prefix of Object.values(QR_PREFIX_V2)) {
+    const { "encrypted-seed-backup": reserved, ...active } = QR_PREFIX_V2
+    for (const prefix of Object.values(active)) {
       expect(isQrCryptPayload(`${prefix}payload`)).toBe(true)
     }
+    expect(isQrCryptPayload(`${reserved}payload`)).toBe(false)
     expect(isQrCryptPayload("OCX9:payload")).toBe(false)
     expect(isQrCryptPayload("plain text")).toBe(false)
   })

--- a/tests/unit/qr-scanner.test.ts
+++ b/tests/unit/qr-scanner.test.ts
@@ -434,7 +434,7 @@ describe("camera scanner lifecycle", () => {
     const onText = vi.fn()
     const onError = vi.fn()
     const decoder = await loadDecoder()
-    zxing.readBarcodes.mockResolvedValueOnce(barcode("OCK1:autoplay"))
+    zxing.readBarcodes.mockResolvedValueOnce(barcode("SCANTEXT:autoplay"))
     const scanPromise = decoder.startQrScan(
       asVideoElement(fakeVideo),
       onText,
@@ -456,7 +456,7 @@ describe("camera scanner lifecycle", () => {
     await flushMicrotasks()
 
     expect(zxing.readBarcodes).toHaveBeenCalledOnce()
-    expect(onText).toHaveBeenCalledWith("OCK1:autoplay")
+    expect(onText).toHaveBeenCalledWith("SCANTEXT:autoplay")
     expect(onError).not.toHaveBeenCalled()
     expect(track.stop).not.toHaveBeenCalled()
     handle.stop()
@@ -683,7 +683,7 @@ describe("camera scanner lifecycle", () => {
       const onText = vi.fn()
       const onError = vi.fn()
       const decoder = await loadDecoder()
-      zxing.readBarcodes.mockResolvedValueOnce(barcode("OCK1:recovered"))
+      zxing.readBarcodes.mockResolvedValueOnce(barcode("SCANTEXT:recovered"))
       const handle = await decoder.startQrScan(
         asVideoElement(fakeVideo),
         onText,
@@ -699,7 +699,7 @@ describe("camera scanner lifecycle", () => {
       await advance(0)
 
       expect(zxing.readBarcodes).toHaveBeenCalledOnce()
-      expect(onText).toHaveBeenCalledWith("OCK1:recovered")
+      expect(onText).toHaveBeenCalledWith("SCANTEXT:recovered")
       expect(onError).not.toHaveBeenCalled()
       expect(fakeVideo.play.mock.calls.length).toBeGreaterThan(1)
       expect(track.stop).toHaveBeenCalledOnce()
@@ -803,7 +803,7 @@ describe("camera scanner lifecycle", () => {
     await advance(0)
 
     handle.stop()
-    pending.resolve(barcode("OCK1:late"))
+    pending.resolve(barcode("SCANTEXT:late"))
     await flushMicrotasks()
 
     expect(onText).not.toHaveBeenCalled()
@@ -829,7 +829,7 @@ describe("camera scanner lifecycle", () => {
     await advance(0)
 
     controller.abort()
-    pending.resolve(barcode("OCK1:late"))
+    pending.resolve(barcode("SCANTEXT:late"))
     await flushMicrotasks()
 
     expect(onText).not.toHaveBeenCalled()
@@ -855,7 +855,7 @@ describe("camera scanner lifecycle", () => {
     await advance(0)
 
     track.end()
-    pending.resolve(barcode("OCK1:late"))
+    pending.resolve(barcode("SCANTEXT:late"))
     await flushMicrotasks()
 
     expect(onText).not.toHaveBeenCalled()
@@ -897,7 +897,7 @@ describe("camera scanner lifecycle", () => {
       vi.fn(),
       { once: false },
     )
-    oldDecode.resolve(barcode("OCK1:old-late"))
+    oldDecode.resolve(barcode("SCANTEXT:old-late"))
     await flushMicrotasks()
     await advance(0)
 
@@ -942,7 +942,7 @@ describe("camera scanner lifecycle", () => {
     await advance(0)
     await advance(decoder.CAMERA_DECODE_PROGRESS_TIMEOUT_MS)
 
-    oldDecode.resolve(barcode("OCK1:old-after-timeout"))
+    oldDecode.resolve(barcode("SCANTEXT:old-after-timeout"))
     replacementDecode.resolve([])
     await flushMicrotasks()
 
@@ -991,7 +991,7 @@ describe("camera scanner lifecycle", () => {
     await advance(decoder.CAMERA_START_TIMEOUT_MS)
     await replacementRejection
 
-    oldDecode.resolve(barcode("OCK1:old-after-timeout"))
+    oldDecode.resolve(barcode("SCANTEXT:old-after-timeout"))
     await flushMicrotasks()
 
     expect(oldText).not.toHaveBeenCalled()
@@ -1009,10 +1009,10 @@ describe("camera scanner lifecycle", () => {
   })
 
   it.each([
-    { once: true, expectedTexts: ["OCK1:first"], expectedReads: 1 },
+    { once: true, expectedTexts: ["SCANTEXT:first"], expectedReads: 1 },
     {
       once: false,
-      expectedTexts: ["OCK1:first", "OCK1:second"],
+      expectedTexts: ["SCANTEXT:first", "SCANTEXT:second"],
       expectedReads: 2,
     },
   ])(
@@ -1024,8 +1024,8 @@ describe("camera scanner lifecycle", () => {
       const onError = vi.fn()
       const decoder = await loadDecoder()
       zxing.readBarcodes
-        .mockResolvedValueOnce(barcode("OCK1:first"))
-        .mockResolvedValueOnce(barcode("OCK1:second"))
+        .mockResolvedValueOnce(barcode("SCANTEXT:first"))
+        .mockResolvedValueOnce(barcode("SCANTEXT:second"))
       const handle = await decoder.startQrScan(
         videoElement(),
         onText,
@@ -1472,12 +1472,12 @@ describe("camera scanner lifecycle", () => {
     getUserMedia.mockResolvedValue(mediaStream(new FakeTrack()))
     const onError = vi.fn()
     const decoder = await loadDecoder()
-    zxing.readBarcodes.mockResolvedValue(barcode("OCK1:SENTINEL-SECRET"))
+    zxing.readBarcodes.mockResolvedValue(barcode("SCANTEXT:SENTINEL-SECRET"))
 
     const handle = await decoder.startQrScan(
       videoElement(),
       () => {
-        throw new Error("delivery failed for OCK1:SENTINEL-SECRET")
+        throw new Error("delivery failed for SCANTEXT:SENTINEL-SECRET")
       },
       onError,
       { once: false },


### PR DESCRIPTION
Four places in this repository stated opposite things about one contract. This branch gives each one a single answer.

## The four

**1. The `oc-*` reset contract had two owners disagreeing.** `clearOcLocalStorage` deletes every `oc-*` key and dispatches `OC_LOCAL_STORAGE_CLEARED_EVENT`. `LanguageProvider` subscribes to that event *and* to the cross-tab `storage` event, returning the language to English. `ThemeProvider` subscribed to neither, so after a reset the app kept showing the pre-wipe theme and re-persisted it on the next theme change. `ThemeProvider` now mirrors `LanguageProvider` exactly: mounted state returns to `system`, and the pre-existing effect persists whatever the new state is. If the state was already `system`, React bails out of the update and the deleted key simply stays absent — both outcomes are correct, so nothing asserts that the key always reappears.

The leak this closes is small; the value is one of `light`/`dark`/`system`. The inconsistency was the defect: two providers with identical storage semantics answering "does a reset own this key?" differently, so the next `oc-*` key added would copy whichever provider its author read first.

**2. A frozen wire constant had two definitions.** `src/qr/payload-v2.ts` owns the v2 prefix table (`docs/spec/qr-protocol-v2.md` §1). `src/qr/relay-frames.ts` already checked frames through `QR_PREFIX_V2.frame`; `src/components/qr-scanner-panel.tsx` used a copied `"OCF2:"` literal — the last such wire literal in `src`. They agree today; now they cannot stop agreeing. No behavior change.

**3. The display side called a payload valid that every decoder rejects.** `payload-v2.ts` states that `OCB2` is reserved only, "unconditionally rejected everywhere (never generate, never accept)", and both `splitV2Payload` and `buildV2Payload` throw `UNSUPPORTED_ALGORITHM` for it. But `isQrCryptPayload` built its set from the whole prefix table, so `OCB2:` came back `true` — and its test, named "recognizes only active v2 prefixes", asserted exactly that. No `src` path can produce an `OCB2:` payload, so no product path changes; a directly supplied one now fails closed.

**4. Three tests did not prove what they appeared to.**

- `contract-smoke.test.ts` asserted that `VITE_DEFAULT_PQ_PROFILE: "balanced"` is rejected. That variable is not in `rawSchema`, so it fails at the unknown-key guard and the value is never evaluated — and the `it.each` directly below already pins that exact path with the exact message.
- `encrypt-page.test.tsx` asserted the absence of `/^OCM1:/` in a case whose result payload is `OCA2:`. The `OCA2:` assertion beside it is the one that proves the result was discarded.
- `qr-scanner.test.ts` used `OCK1:` strings as arbitrary decoded text and asserted they are *delivered*, while `keys-settings.test.tsx` uses the same prefix to assert it is *rejected*. The layering is correct — `src/qr/decode.ts` is deliberately prefix-agnostic and the UI owns prefix policy — but one literal carried two meanings. The fixtures are now `SCANTEXT:`.

## Documentation

`docs/spec/boot-and-reset-v2.md` §4 step 6 inventoried which preferences revert after a wipe and named two of three. It now names the theme too. That file belongs to the `protocol-docs` freshness unit, whose verify (`aube run test:pq && aube run test -- tests/ui/boot-controller.test.tsx`) passed; `last_checked` was already today, so no registry stamp was owed. No other changed file is named by any freshness unit or invariant.

## Out of scope, reported not fixed

`docs/spec/qr-protocol-v2.md:28-30` says `OCB2` is rejected "at classification time", but `classifyV2Payload` returns the reserved kind and `splitV2Payload` throws afterwards. Real, pre-existing, and untouched here.

## Verification

Run independently of the implementing agent:

```
make check   typecheck passed; lint 0 errors, 16 warnings
             (origin/dev also has 16 — no new warnings)
             63 files passed, 878 tests passed
make e2e     28 passed
```

The theme-reset test was authored by a pane that never saw the implementation, and was observed failing on the real assertions before the source change landed.

## Review status

The plan received the full double review — two independent agent types, one rejecting the first draft, and both sets of findings are folded into what shipped.

The final branch review is **single, not double**: the second reviewer's agent type hit its usage limit mid-review, and its configured substitute had no pane inside this run's delegation scope. The review that completed found no defects and approved the merge. Flagging it rather than presenting this as a doubly-reviewed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
