### PR TITLE
docs: rewrite the artful-simplicity and nation-state-security skill bars

### DIFF
--- a/.claude/skills/artful-simplicity/SKILL.md
+++ b/.claude/skills/artful-simplicity/SKILL.md
@@ -1,42 +1,23 @@
 ---
 name: artful-simplicity
-description: Ask whether this repository's simplicity — implementation design, logic, tests, docs and comments — is at the level of art. Use for design review, simplicity audit, excessive tests, redundant comments, over-engineering audit, /artful-simplicity.
+description: Audit code, tests, and prose for artful simplicity; use for design, over-engineering, and redundancy reviews.
 ---
 
 # Artful simplicity
 
-Is the simplicity of this repository's implementation design, logic, tests, and
-docs/comments at the level of art? In particular, do the tests cover only logic,
-and do the docs and comments say what is needed in the shortest words?
+A unit is simple when a cold reader can name its one idea, predict its contents
+from its name, and keep nothing unrelated in mind. Tests cover only logic; prose
+says only what is needed.
 
-## The bar
+Local reading judges clarity, not necessity. It may justify `rewrite`; `delete`,
+`fold`, and boundary moves remain hypotheses. Evidence required: for deletion,
+repository-wide reachability, freshness/invariant protection, and security
+consequence; for folding, equivalence across every observable state and
+transition—including pending, already-resolved, cancellation, close/reopen, and
+error; for boundaries, convergence of at least two independent readings.
 
-Textbook: from one file alone, a competent engineer who has never seen this
-repository can name the single idea it embodies, predict its body from its name,
-and hold nothing else in their head.
+Seek contradictions, not volume. Before behavior changes, state the change,
+reachable observer, safety direction, and what the opposite choice breaks.
+Direction decides, not size.
 
-- A cold reading decides local comprehensibility and nothing else. "What breaks
-  without it?" is a repository-level question and the reader has one file, so a
-  reader who answers "nothing" is following the procedure correctly and is often
-  wrong. `delete` and `fold` are candidate labels, never prescriptions; `rewrite`
-  needs no evidence beyond the reading.
-- Delete only after proving reachability across `src` and `tests`, that no
-  freshness unit or invariant names it, and stating the security consequence of
-  its removal.
-- Fold only after a semantic-equivalence proof covering pending,
-  already-resolved, cancellation, close/reopen, and error. That list is not
-  generic: an argument that covered the unresolved async state and never examined
-  the already-resolved one is how the one avoidable behavior regression shipped.
-- Hunt contradictions, not excess. Every real finding so far was two things
-  disagreeing — two definitions of one function, two surfaces disagreeing about
-  one switch — not too much code.
-- Move a concept between files only when two or more independent readers placed
-  its pieces in different files. That is what separates a discovered boundary
-  from an invented one.
-- State four things before any behavior change: what changes; who observes it, as
-  a reachable path; direction, safer or less safe; what breaks under the opposite
-  choice. Direction decides, not size.
-
-Never a finding: whatever `../freshness/targets.yaml` marks append-only or frozen.
-Deleting one of those wipes stored preferences or breaks a golden; it does not
-simplify.
+Exclude append-only/frozen targets in `../freshness/targets.yaml`.

--- a/.claude/skills/nation-state-security/SKILL.md
+++ b/.claude/skills/nation-state-security/SKILL.md
@@ -1,13 +1,106 @@
 ---
 name: nation-state-security
-description: Review whether this application is structured so that plaintext cannot be leaked even under nation-state-level attack.
+description: >
+  Assess QR Crypt against a recorded advanced-adversary profile and produce
+  actionable, evidence-bounded findings. Do not certify the system as
+  nation-state-proof.
 ---
 
-Review whether this application is structured so that plaintext cannot be leaked
-even under nation-state-level attack. Prioritize T21 as a structural residual risk arising from compromise of the offline execution environment, rather than merely a Relay implementation flaw.
+# Scope
 
-- The offline device will not be seized.
-- wipe is insurance; once the application has been installed on a device, that
-  device is never connected to a network.
-- Method A is the intended path; the possibility of tampering with Method B is
-  accepted.
+Review the current repository state across:
+
+1. source, build, and release;
+2. installation and verification;
+3. online relay;
+4. offline execution; and
+5. offline physical and operational environment.
+
+The result is a scoped risk assessment, not a certification.
+
+# Adversary model
+
+For every review, record assumed, excluded, and uncertain capabilities for:
+
+- physical access: phase, duration, and supervision;
+- time horizon: pre-deployment through post-operation;
+- supply-chain reach;
+- platform compromise;
+- proximity and surveillance; and
+- targeting scale and persistence.
+
+“Nation-state” does not imply unlimited capability.
+
+# Control classes
+
+Classify every finding as exactly one of:
+
+- `REPOSITORY_IMPLEMENTABLE`
+- `DEPLOYMENT_ENFORCED`
+- `EXTERNAL_ASSURANCE`
+- `ARCHITECTURAL_RESIDUAL`
+
+Repository controls require objective acceptance criteria and tests. Deployment
+and external controls must not be described as application features.
+
+# Invariants
+
+- Signatures establish origin only under a defined trust policy; they do not
+  establish benign source, uncompromised tooling, or source-to-binary
+  correspondence.
+- A compromised offline endpoint may exfiltrate secrets through valid outbound
+  data; relay validation does not close T21.
+- Application code cannot secure a compromised platform, peripheral, operator,
+  or physical environment.
+- Route B requires an independent authenticity mechanism for any
+  high-assurance installation claim.
+- Do not make absolute security or side-channel claims.
+
+# Environment threats
+
+The authoritative catalog is:
+
+`docs/security/environment-threat-catalog.md`
+
+For every relevant review, assess its currency and applicability. Add only
+techniques with a credible relationship to the system, distinguish evidence
+from speculation, and propagate material changes to models, findings,
+implementation, tests, and claims.
+
+Do not duplicate the evolving attack list in this skill.
+
+# Review procedure
+
+Record the reviewed revision, date, adversary profile, assumptions, and
+evidence. Inspect implementation, tests, release workflows, installation
+documentation, threat models, reviews, and the environment catalog. Separate
+control existence from evidence of effectiveness and identify contradictions
+or unsupported claims.
+
+For each material catalog change:
+
+- record affected boundaries, assumptions, threats, controls, tests,
+  documentation, residual risk, and assurance claims—or a no-impact rationale;
+- verify identifiers, classifications, evidence, tests, cross-document
+  consistency, and user-visible claims after the change.
+
+For each finding, provide:
+
+- boundary, threat, prerequisites, assets, evidence, and status;
+- control class and proposed response;
+- objective verification criteria and applicable tests;
+- documentation changes and residual risk;
+- consequence if the threat succeeds or a relied-upon control fails;
+- impact severity: `CRITICAL`, `HIGH`, `MODERATE`, or `LOW`;
+- affected scope and severity rationale;
+- feasibility under the recorded adversary profile; and
+- dated sources where external evidence is used.
+
+Severity describes consequence assuming success. Do not reduce severity because
+feasibility is low; record feasibility separately.
+
+# Required conclusion
+
+Prioritize repository changes, deployment controls, external assurance,
+architectural residuals, and documentation updates. State only the precise
+assurance supported by the reviewed evidence.


### PR DESCRIPTION
## Summary

- Rewrite `.claude/skills/artful-simplicity/SKILL.md` into a shorter operational bar: cold-reader clarity, evidence required for delete/fold/boundary moves, hunt contradictions not volume, and exclude freshness append-only/frozen targets.
- Expand `.claude/skills/nation-state-security/SKILL.md` from a short plaintext-leak prompt into a scoped advanced-adversary review procedure: record assumed/excluded capabilities, classify controls, require evidence-bounded findings, and explicitly refuse nation-state-proof certification claims.
- Point environment-threat review at `docs/security/environment-threat-catalog.md` instead of duplicating an attack list in the skill.

## Test plan

- [ ] Confirm both skills still resolve under project instruction pointers (`CLAUDE.md` / skill discovery)
- [ ] Skim artful-simplicity: a reviewer can apply delete/fold/rewrite rules without the old long-form prose
- [ ] Skim nation-state-security: procedure requires adversary profile, control class, severity-vs-feasibility split, and a non-certification conclusion
- [ ] Verify referenced path `docs/security/environment-threat-catalog.md` exists on `dev` (or follow up if the catalog lands separately)