### PR TITLE
fix: assert the created tag from its create response, retry only real 404s

### DIFF
--- a/.claude/skills/freshness/targets.yaml
+++ b/.claude/skills/freshness/targets.yaml
@@ -117,6 +117,7 @@ units:
       - docs/languages/ja/develop/install-route-a/README.md # Japanese mirror under docs/languages/<lang>/; must not diverge from README.md
       - scripts/serve-dist.mjs # header-aware server called directly by the release workflow
       - tests/unit/serve-dist.test.ts # executable containment and server startup contract
+      - tests/unit/release-tag-read.test.ts # extracts assert_canonical_tag and read_canonical_tag from github-release.yml; breaks if either helper is renamed or reshaped
     why: >
       CI action majors, immutable action SHAs, the pinned Cosign binary/verifier
       image, and GitHub runner/CLI behavior all drift with upstream releases.
@@ -149,6 +150,7 @@ units:
     verify: |
       Local only — a freshness sweep must not push:
       aube run test -- tests/unit/serve-dist.test.ts
+      aube run test -- tests/unit/release-tag-read.test.ts
       mise x \
         github:rhysd/actionlint@v1.7.12 \
         github:koalaman/shellcheck@v0.11.0 -- \

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1163,6 +1163,39 @@ jobs:
               --certificate-github-workflow-trigger "push"
           }
 
+          assert_canonical_tag() {
+            local context="$1"
+            [[ "$(jq -r '.object.type' "$tag_json")" == "commit" ]] ||
+              fail "$context: canonical tag is not a lightweight commit tag"
+            [[ "$(jq -r '.object.sha' "$tag_json")" == "$SOURCE_SHA" ]] ||
+              fail "$context: canonical tag does not resolve to $SOURCE_SHA"
+          }
+
+          # GitHub serves ref reads from replicas, so a ref can 404 for a
+          # moment after it is written. Retry only that transient absence, and
+          # only on an explicit HTTP 404 — a 500 whose text happens to read
+          # "not found" is a real error. A ref that reads back with the wrong
+          # target is a tag move: it fails on the first readable response
+          # rather than being re-polled until some replica agrees.
+          read_canonical_tag() {
+            local context="$1" attempt
+            for attempt in 1 2 3 4 5 6; do
+              if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+                > "$tag_json" 2> "$tag_error"; then
+                assert_canonical_tag "$context"
+                return 0
+              fi
+              grep -q 'HTTP 404' "$tag_error" || {
+                cat "$tag_error" >&2 || true
+                fail "$context: canonical tag read failed"
+              }
+              [[ "$attempt" -lt 6 ]] || break
+              sleep 2
+            done
+            cat "$tag_error" >&2 || true
+            fail "$context: canonical tag did not become readable"
+          }
+
           tag_exists=false
           if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
             > "$tag_json" 2> "$tag_error"; then
@@ -1172,7 +1205,7 @@ jobs:
             tag_sha="$(jq -r '.object.sha' "$tag_json")"
             [[ "$tag_sha" == "$SOURCE_SHA" ]] ||
               fail "existing tag resolves to $tag_sha instead of $SOURCE_SHA"
-          elif ! grep -Eqi 'HTTP 404|Not Found' "$tag_error"; then
+          elif ! grep -q 'HTTP 404' "$tag_error"; then
             cat "$tag_error" >&2
             fail "could not determine whether the canonical tag exists"
           fi
@@ -1201,17 +1234,15 @@ jobs:
           [[ "$IMMUTABILITY_ACKNOWLEDGED" == "true" ]] ||
             fail "enable Release immutability, then set repository variable RELEASE_IMMUTABILITY_ENABLED=true"
 
+          # The create response is the authoritative ref object, so it is
+          # asserted directly instead of read back — the read-back is what
+          # raced GitHub's ref replication and failed run 30716158737.
           if [[ "$tag_exists" == "false" ]]; then
             gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
               -f "ref=refs/tags/$RELEASE_TAG" \
-              -f "sha=$SOURCE_SHA" > /dev/null
+              -f "sha=$SOURCE_SHA" > "$tag_json"
           fi
-          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
-            > "$tag_json"
-          [[ "$(jq -r '.object.type' "$tag_json")" == "commit" ]] ||
-            fail "canonical tag is not a lightweight commit tag"
-          [[ "$(jq -r '.object.sha' "$tag_json")" == "$SOURCE_SHA" ]] ||
-            fail "canonical tag does not resolve to the source commit"
+          assert_canonical_tag "canonical tag"
 
           create_payload="$RUNNER_TEMP/create-release.json"
           create_error="$RUNNER_TEMP/create-release.error"
@@ -1279,12 +1310,7 @@ jobs:
           assert_exact_draft_assets
 
           # Close the mutable-draft tag race immediately before publication.
-          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
-            > "$tag_json"
-          [[ "$(jq -r '.object.type' "$tag_json")" == "commit" ]] ||
-            fail "canonical tag ceased to be a lightweight commit tag"
-          [[ "$(jq -r '.object.sha' "$tag_json")" == "$SOURCE_SHA" ]] ||
-            fail "canonical tag moved before publication"
+          read_canonical_tag "pre-publication"
 
           publish_payload="$RUNNER_TEMP/publish-release.json"
           jq -n \
@@ -1301,12 +1327,7 @@ jobs:
             "repos/$GITHUB_REPOSITORY/releases/$release_id" \
             --input "$publish_payload" > /dev/null
 
-          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
-            > "$tag_json"
-          [[ "$(jq -r '.object.type' "$tag_json")" == "commit" ]] ||
-            fail "published tag is not a lightweight commit tag"
-          [[ "$(jq -r '.object.sha' "$tag_json")" == "$SOURCE_SHA" ]] ||
-            fail "published tag does not resolve to the source commit"
+          read_canonical_tag "post-publication"
 
           load_published_release_after_publication
           assert_exact_published_release

--- a/tests/unit/release-tag-read.test.ts
+++ b/tests/unit/release-tag-read.test.ts
@@ -1,0 +1,185 @@
+import { spawn } from "node:child_process"
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const workflowPath = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "github-release.yml",
+)
+
+const INDENT = "          "
+
+const extractFunction = (source: string, name: string): string => {
+  const lines = source.split("\n")
+  const start = lines.indexOf(`${INDENT}${name}() {`)
+  if (start === -1) {
+    throw new Error(`HELPER_NOT_FOUND:${name}`)
+  }
+  const end = lines.findIndex(
+    (line, index) => index > start && line === `${INDENT}}`,
+  )
+  if (end === -1) {
+    throw new Error(`HELPER_UNTERMINATED:${name}`)
+  }
+  return lines
+    .slice(start, end + 1)
+    .map((line) => line.slice(INDENT.length))
+    .join("\n")
+}
+
+const matchingSha = "1111111111111111111111111111111111111111"
+const movedSha = "2222222222222222222222222222222222222222"
+
+interface Outcome {
+  code: number | null
+  stderr: string
+  calls: number
+}
+
+// One line of the response plan is consumed per `gh` invocation:
+//   ok:<type>:<sha>  print a ref object with that type and sha, exit 0
+//   404              print gh's own 404 wording on stderr, exit 1
+//   err:<text>       print <text> on stderr, exit 1
+const ghStub = (callLog: string, planPath: string): string =>
+  [
+    "#!/usr/bin/env bash",
+    `printf 'call\\n' >> ${JSON.stringify(callLog)}`,
+    `count=$(wc -l < ${JSON.stringify(callLog)})`,
+    `response=$(sed -n "\${count}p" ${JSON.stringify(planPath)})`,
+    'case "$response" in',
+    "  ok:*)",
+    '    rest="${response#ok:}"',
+    '    printf \'{"object":{"type":"%s","sha":"%s"}}\\n\' "${rest%%:*}" "${rest#*:}"',
+    "    exit 0",
+    "    ;;",
+    "  404)",
+    "    printf 'gh: Not Found (HTTP 404)\\n' >&2",
+    "    exit 1",
+    "    ;;",
+    "  *)",
+    '    printf \'%s\\n\' "${response#err:}" >&2',
+    "    exit 1",
+    "    ;;",
+    "esac",
+  ].join("\n")
+
+const runHelper = async (responses: string[]): Promise<Outcome> => {
+  const directory = await mkdtemp(path.join(tmpdir(), "qrypt-tag-read-"))
+  try {
+    const binDirectory = path.join(directory, "bin")
+    const callLog = path.join(directory, "calls")
+    const planPath = path.join(directory, "plan")
+    await mkdir(binDirectory, { recursive: true })
+    await writeFile(callLog, "")
+    await writeFile(planPath, `${responses.join("\n")}\n`)
+
+    const stubPath = path.join(binDirectory, "gh")
+    await writeFile(stubPath, `${ghStub(callLog, planPath)}\n`)
+    await chmod(stubPath, 0o755)
+
+    const workflow = await readFile(workflowPath, "utf8")
+    const harness = [
+      "set -euo pipefail",
+      "fail() { printf 'release publication error: %s\\n' \"$*\" >&2; exit 1; }",
+      "sleep() { :; }",
+      'GITHUB_REPOSITORY="owner/repo"',
+      'RELEASE_TAG="v0.1.0-main.gdeadbeef"',
+      `SOURCE_SHA=${JSON.stringify(matchingSha)}`,
+      `tag_json=${JSON.stringify(path.join(directory, "tag.json"))}`,
+      `tag_error=${JSON.stringify(path.join(directory, "tag.error"))}`,
+      extractFunction(workflow, "assert_canonical_tag"),
+      extractFunction(workflow, "read_canonical_tag"),
+      'read_canonical_tag "test"',
+    ].join("\n")
+    const scriptPath = path.join(directory, "harness.sh")
+    await writeFile(scriptPath, `${harness}\n`)
+
+    return await new Promise<Outcome>((resolve, reject) => {
+      const child = spawn("bash", [scriptPath], {
+        env: {
+          ...process.env,
+          PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+        },
+      })
+      let stderr = ""
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString()
+      })
+      child.once("error", reject)
+      child.once("close", (code) => {
+        void readFile(callLog, "utf8").then((log) => {
+          resolve({
+            code,
+            stderr,
+            calls: log.split("\n").filter((line) => line.length > 0).length,
+          })
+        }, reject)
+      })
+    })
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+describe("read_canonical_tag", () => {
+  it("retries through replication lag and then succeeds", async () => {
+    const outcome = await runHelper(["404", "404", `ok:commit:${matchingSha}`])
+    expect(outcome.code).toBe(0)
+    expect(outcome.calls).toBe(3)
+  })
+
+  // A readable response that disagrees is a tag move, never lag. It must fail
+  // on the first read: a second response is supplied that WOULD satisfy the
+  // helper, so any retry turns these into a pass or a call count above one.
+  it.each([
+    {
+      name: "the tag resolves to another commit",
+      first: `ok:commit:${movedSha}`,
+      expected: "does not resolve",
+    },
+    {
+      name: "the tag is not a lightweight commit tag",
+      first: `ok:tag:${matchingSha}`,
+      expected: "not a lightweight commit tag",
+    },
+  ])("fails on the first read when $name", async ({ first, expected }) => {
+    const outcome = await runHelper([first, `ok:commit:${matchingSha}`])
+    expect(outcome.code).toBe(1)
+    expect(outcome.stderr).toContain(expected)
+    expect(outcome.calls).toBe(1)
+  })
+
+  // Only an explicit HTTP 404 is lag. Anything else fails immediately, even
+  // when its text happens to contain the words "Not Found".
+  it.each([
+    { name: "a server error", first: "err:gh: Internal Server Error (HTTP 500)" },
+    { name: "a 500 whose text says Not Found", first: "err:gh: Not Found (HTTP 500)" },
+    { name: "a local error mentioning Not Found", first: "err:gh: credential helper file Not Found" },
+  ])("fails immediately on $name", async ({ first }) => {
+    const outcome = await runHelper([first, `ok:commit:${matchingSha}`])
+    expect(outcome.code).toBe(1)
+    expect(outcome.stderr).toContain("canonical tag read failed")
+    expect(outcome.calls).toBe(1)
+  })
+
+  it("gives up after a bounded number of 404s", async () => {
+    const outcome = await runHelper([
+      "404",
+      "404",
+      "404",
+      "404",
+      "404",
+      "404",
+      `ok:commit:${matchingSha}`,
+    ])
+    expect(outcome.code).toBe(1)
+    expect(outcome.stderr).toContain("did not become readable")
+    expect(outcome.calls).toBe(6)
+  })
+})


### PR DESCRIPTION
## What broke

Run [30716158737](https://github.com/transparent-pegasus/qr-crypt/actions/runs/30716158737) (`Release main build`, main `e71510e7`) emitted exactly one diagnostic — `gh: Not Found (HTTP 404)` — then exit 1, with no `release publication error:` line. That means it died on an unguarded `gh` under `set -e`, not on one of the workflow's own assertions.

Afterwards the tag `refs/tags/v0.1.0-main.ge71510e7...` exists and points at the right commit, and no release — not even a draft — exists for it. That places the death between the ref create at `:1205` and the draft create at `:1231`: the read-back at `:1209` of a ref written milliseconds earlier, served by a replica that had not caught up.

## The fix is a deletion, not a retry

The read-back was redundant. On the create path the POST response is already the authoritative ref object; on the pre-existing path the probe at `:1168` has already validated the same two fields. So it is removed — the POST now writes its response to `$tag_json` and `assert_canonical_tag` checks that directly. **No read-after-write is left to lag.**

Retrying it instead would have been a small net loosening: a 404 on attempt 1 followed by a stale replica returning the old matching SHA on attempt 2 accepts a tag that moved in between, where today's unguarded read dies on the 404.

The two later race checks at `:1282`/`:1304` must genuinely re-read the ref to detect a tag move, so those get `read_canonical_tag` — bounded at 6 attempts 2s apart, retrying **only** an explicit `HTTP 404`.

## Also tightened

The pre-existence probe matched `HTTP 404|Not Found` case-insensitively, so a 500 whose body happened to say "not found" read as "the tag does not exist" and the workflow proceeded to **create** it. `gh api` always reports its status as `(HTTP nnn)`, so requiring `HTTP 404` is sufficient and strictly tighter. The release probe at `:1186` keeps its pattern — `gh release view` reports a missing release with no HTTP status line.

## Guarantees and limits

- A readable canonical tag disagreeing with `$SOURCE_SHA`, in type or SHA, fails on the **first** readable response — never re-polled until some replica agrees.
- A `gh` failure without an explicit `HTTP 404` is never treated as lag.
- A 404 is **not** proof of absence — GitHub returns 404 for some authorization failures. The reading here is an inference, sound because the same token already read and wrote this repository earlier in the same step.
- Ten seconds is **not** an SLA. GitHub publishes no ref-replication guarantee; if the ref never becomes readable the job still fails.
- **Residual:** at the two race-check sites, a 404 followed by a stale replica returning the old matching SHA would mask a tag move made in between. Bounded by what follows — release immutability, `gh release verify`, and cosign `verify-blob` pinned to `--certificate-github-workflow-sha "$SOURCE_SHA"` — so a moved tag still cannot yield a valid published artifact for another commit.

## Out of scope, deliberately

`gh release upload` (`:1271`) and the publish `PATCH` (`:1300`) are mutations needing their own idempotency argument. The release GET by ID (`:1277`) has the same lag shape and is a recorded follow-up, not yet observed failing.

## Test

`tests/unit/release-tag-read.test.ts` extracts both helpers **out of the YAML** rather than copying them, so it cannot pass against logic that no longer matches the workflow, and drives them under `bash` with a stubbed `gh` and a `sleep` shadow. Seven cases; the ones that matter assert `calls === 1` on a readable mismatch — the fail-closed contract.

Verified by mutation: widening the 404 classifier back fails 2 cases; raising the retry bound fails 1; making a SHA mismatch retry fails 1. (The `|| true` on the diagnostic `cat` is unpinned — `$tag_error` is always created by the `2>` redirect, so no test can make `cat` fail.)

Registered in the `ci-actions` freshness unit.

## Verification

- `make check` — typecheck clean, lint 0 errors (16 pre-existing warnings). Tests 908/909; the one failure is the known `tests/ui/encrypt-page.test.tsx` full-suite-parallel flake, 24/24 in isolation.
- `actionlint .github/workflows/*.yml` — exit 0.
- `shellcheck -s bash` over the extracted 434-line publication run block — exit 0.

## Review status

The **plan** got an independent double review (codex + grok); codex's finding is what turned this from "retry everywhere" into "delete the read". The **branch** did not get an independent review — delegation was stopped partway by instruction, and `task-review` is disabled in this repo's config. Worth a human read of `github-release.yml` before merge.