### PR TITLE
docs: say why the bundle save needs no persist gate

### DIFF
--- a/src/components/key-add-dialog.tsx
+++ b/src/components/key-add-dialog.tsx
@@ -468,6 +468,8 @@ export function KeyAddDialog({
     }
   }
 
+  // No persist() here, unlike the import above: this view is already locked by
+  // its kind, and a public bundle is not sensitive data — boot never scans it.
   const savePendingBundle = async (confirmed: boolean) => {
     if (view.kind !== "bundle-confirm" || (confirmed && !fingerprintChecked)) return
     const opening = openingRef.current


### PR DESCRIPTION
Follow-up to #71. Comment-only change, no behaviour touched.

`savePendingBundle` in `src/components/key-add-dialog.tsx` deliberately skips the `persist()` call that the import path above it makes. Records the reason inline so the asymmetry does not read as an omission: the view is already locked by its kind, and a public bundle is not sensitive data — boot never scans it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)