### PR TITLE
chore: artful-simplicity round 2 — delete duplicated export logic, duplicated prose, and a dead type

### DIFF
--- a/.claude/skills/freshness/targets.yaml
+++ b/.claude/skills/freshness/targets.yaml
@@ -353,7 +353,7 @@ units:
   - id: protocol-docs
     category: docs
     cadence_days: 90 # also on any protocol/boot change
-    last_checked: 2026-08-03
+    last_checked: 2026-08-06
     files:
       - docs/spec/qr-protocol-v2.md
       - docs/spec/boot-and-reset-v2.md
@@ -405,7 +405,7 @@ units:
       allowlist and completed-set assembled-artifact validation match
       relay-frames.ts and its unit/UI tests. Confirm qr-display.tsx still
       requires the size prop so no surface can render off that contract. Confirm the
-      qr-protocol-v2.md messageId note (~169–170) still states the wire format
+      qr-protocol-v2.md messageId note (~259–264) still states the wire format
       is not a replay-prevention mechanism while documenting the receiving
       session-memory receipt keyed by it, and that the clarification matches
       src/features/receipt-cache.ts (no wire change). Diff

--- a/src/components/key-detail-dialog.tsx
+++ b/src/components/key-detail-dialog.tsx
@@ -59,6 +59,7 @@ import {
   useLocalizedMessage,
   type LocalizedMessage,
 } from "@/i18n"
+import { copyTextToClipboard } from "@/lib/clipboard"
 import {
   FRAME_BYTES_MAX,
   minimumFrameBytesForArtifact,
@@ -66,7 +67,6 @@ import {
 } from "@/lib/limits"
 import {
   buildExportFileName,
-  copyTextToClipboard,
   qrPngBlob,
   triggerDownload,
 } from "@/qr/export-image"

--- a/src/components/online-relay.tsx
+++ b/src/components/online-relay.tsx
@@ -27,13 +27,13 @@ import { Textarea } from "@/components/ui/textarea"
 import { AppError, errorMessageKey } from "@/crypto/errors"
 import { formatFramePositions } from "@/features/presentation"
 import { useQrReaderReadiness } from "@/hooks/use-qr-reader-readiness"
+import { copyTextToClipboard } from "@/lib/clipboard"
 import {
   RELAY_PLAYBACK_FRAME_INTERVAL_MS,
   TRANSFER_TIMEOUT_MINUTES_DEFAULT,
 } from "@/lib/limits"
 import { reloadApplication } from "@/lib/reload"
 import { startQrScan, type QrScanHandle } from "@/qr/decode"
-import { copyTextToClipboard } from "@/qr/export-image"
 import { prepareRelayPlayback } from "@/qr/relay-playback"
 import { acquireRelayLease, type RelayLease } from "@/storage/database"
 import {

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,10 @@
+// Clipboard writes, mapped to the storage failure domain.
+import { toAppError } from "@/crypto/errors"
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch (error) {
+    throw toAppError(error, "STORAGE_FAILED")
+  }
+}

--- a/src/pages/encrypt-page.tsx
+++ b/src/pages/encrypt-page.tsx
@@ -58,9 +58,9 @@ import {
   type LocalizedMessage,
 } from "@/i18n"
 import { utf8ToBytes } from "@/lib/bytes"
+import { copyTextToClipboard } from "@/lib/clipboard"
 import { effectiveGeneratedDisplay } from "@/lib/generated-display"
 import { MAX_SYM_PLAINTEXT_BYTES } from "@/lib/limits"
-import { copyTextToClipboard } from "@/qr/export-image"
 import { exportQrFramePayloads } from "@/qr/export-frames"
 import { encodeFrameToPayload } from "@/qr/payload-v2"
 import { type UiAlgorithm } from "@/schemas/domain"

--- a/src/qr/export-image.ts
+++ b/src/qr/export-image.ts
@@ -1,4 +1,4 @@
-// QR PNG/SVG/text export and download.
+// QR image export, file naming, and download.
 // Filenames must not contain secret information, plaintext, or key material.
 import type { QrEcLevel } from "@/schemas/domain"
 import * as QRCode from "qrcode"
@@ -85,13 +85,5 @@ export function triggerDownload(blob: Blob, fileName: string): void {
     URL.revokeObjectURL(url)
   } catch {
     throw new AppError("STORAGE_FAILED")
-  }
-}
-
-export async function copyTextToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text)
-  } catch (error) {
-    throw toAppError(error, "STORAGE_FAILED")
   }
 }

--- a/src/schemas/domain.ts
+++ b/src/schemas/domain.ts
@@ -161,7 +161,7 @@ export interface PqPublicBundleRecord {
 
 export interface MessageBodyCommonV2 {
   version: 2
-  messageId: Uint8Array // Fixed 16B from the CSPRNG; not replay prevention (§G).
+  messageId: Uint8Array // Fixed 16B from the CSPRNG; not replay prevention (§5).
   createdAt: number // Device-asserted time, not trusted time.
   recipientKemKeyId: string
   plaintext: Uint8Array

--- a/src/schemas/domain.ts
+++ b/src/schemas/domain.ts
@@ -156,7 +156,7 @@ export interface PqPublicBundleRecord {
 }
 
 // ---------------------------------------------------------------------------
-// v2 inner messages as a strict discriminated union; see docs/spec/qr-protocol-v2.md §5.
+// v2 signed inner message; see docs/spec/qr-protocol-v2.md §5.
 // ---------------------------------------------------------------------------
 
 export interface MessageBodyCommonV2 {
@@ -179,8 +179,6 @@ export interface SignedMessageV2 {
     value: Uint8Array
   }
 }
-
-export type InnerMessageV2 = SignedMessageV2
 
 // ---------------------------------------------------------------------------
 // v2 outer envelopes and AAD; see docs/spec/qr-protocol-v2.md §3.

--- a/tests/ui/animated-qr-frames.test.tsx
+++ b/tests/ui/animated-qr-frames.test.tsx
@@ -14,10 +14,8 @@ import type { QrFrameV2 } from "@/schemas/domain"
 import { env } from "@/schemas/env-schema"
 import { deferred } from "../helpers/deferred"
 import {
-  exportQrFramePayloads,
   qrPngBlob,
   renderQrDataUrl,
-  sanitizeQrFileName,
   triggerDownload,
 } from "./helpers/fakes"
 import { resetUi } from "./helpers/render-app"
@@ -285,7 +283,7 @@ describe("AnimatedQrFrames", () => {
       <AnimatedQrFrames
         frames={[frame(0, 2), frame(1, 2)]}
         frameIntervalMs={1_000}
-        outputName="multiple"
+        outputName="multi/ple"
       />,
     )
 
@@ -309,32 +307,12 @@ describe("AnimatedQrFrames", () => {
     expect(archiveText).toContain("frame-02.png")
   })
 
-  it("passes protocol frame indexes and the output name to the shared export", async () => {
-    render(
-      <AnimatedQrFrames
-        frames={[frame(0, 2), frame(1, 2)]}
-        frameIntervalMs={1_000}
-        outputName="shared-export"
-      />,
-    )
-
-    fireEvent.click(screen.getByRole("button", { name: "Download" }))
-
-    await waitFor(() =>
-      expect(exportQrFramePayloads).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({
-            frameIndex: expect.any(Number),
-            payload: expect.any(String),
-          }),
-        ]),
-        expect.objectContaining({
-          outputName: "shared-export",
-          size: expect.any(Number),
-        }),
-      ),
-    )
-  })
+  // The export call shape is no longer worth its own test: the exporter runs
+  // for real here, so the ZIP test above observes the output name and the
+  // entry names it produces. A gapped frame set cannot be exercised from this
+  // layer at all — Download stays disabled while any frame is missing — so
+  // "protocol frame index, not array position" is pinned where a gap can
+  // actually be built, in tests/unit/qr-frame-export.test.ts.
 
   it("stays parent-controlled until fullscreenOpen is rerendered", async () => {
     const onFullscreenOpenChange = vi.fn()
@@ -389,7 +367,6 @@ describe("AnimatedQrFrames", () => {
     )
 
     expect(screen.queryByRole("button", { name: "Download" })).toBeNull()
-    expect(sanitizeQrFileName).not.toHaveBeenCalled()
     expect(qrPngBlob).not.toHaveBeenCalled()
     expect(triggerDownload).not.toHaveBeenCalled()
   })

--- a/tests/ui/encrypt-page.test.tsx
+++ b/tests/ui/encrypt-page.test.tsx
@@ -20,11 +20,11 @@ import { deferred } from "../helpers/deferred"
 import {
   encryptPq,
   encodeSymMessageEnvelopeV2,
-  exportQrFramePayloads,
   fakeBundles,
   fakeIdentities,
   fakeKeys,
   fakePreferences,
+  qrPngBlob,
   renderQrDataUrl,
   sealSymMessage,
   splitIntoFrames,
@@ -1055,7 +1055,9 @@ describe("encrypt page v2", () => {
 
   it("shows an export failure inside the modal", async () => {
     const user = userEvent.setup()
-    exportQrFramePayloads.mockRejectedValueOnce(new AppError("QR_TOO_LARGE"))
+    // The real exporter awaits qrPngBlob per frame and catches nothing, so a
+    // rejected blob is how the export fails now.
+    qrPngBlob.mockRejectedValueOnce(new AppError("QR_TOO_LARGE"))
     await renderApp("/encrypt")
     await chooseSelectOption(
       user,
@@ -1119,8 +1121,10 @@ describe("encrypt page v2", () => {
 
   it("F3 isolates a replacement result from a dismissed export", async () => {
     const user = userEvent.setup()
-    const staleExport = deferred<void>()
-    exportQrFramePayloads.mockReturnValueOnce(staleExport.promise)
+    // Pin the real export loop on its first blob: the whole stale export stays
+    // in flight until this settles.
+    const staleExport = deferred<Blob>()
+    qrPngBlob.mockReturnValueOnce(staleExport.promise)
     await renderApp("/encrypt")
     await chooseSelectOption(
       user,
@@ -1139,7 +1143,7 @@ describe("encrypt page v2", () => {
     })
     await waitFor(() => expect(firstDownload).toBeEnabled())
     await user.click(firstDownload)
-    await waitFor(() => expect(exportQrFramePayloads).toHaveBeenCalledOnce())
+    await waitFor(() => expect(qrPngBlob).toHaveBeenCalledOnce())
     await waitFor(() => expect(firstDownload).toBeDisabled())
     await user.click(within(firstResult).getByRole("button", { name: "Close" }))
     await waitFor(() =>

--- a/tests/ui/helpers/fakes.ts
+++ b/tests/ui/helpers/fakes.ts
@@ -4,7 +4,6 @@ import type { RegisterSWOptions } from "virtual:pwa-register/react"
 import { AppError, type ErrorCode } from "@/crypto/errors"
 import type { DecryptPqMessageArgs } from "@/crypto/pq/decrypt-orchestrator"
 import type { ReceiptSubject, ReceiptVerdict } from "@/features/receipt-cache"
-import { storeOnlyZip } from "@/lib/best-effort-zip"
 import { fromBase64Url } from "@/lib/base64url"
 import type { FeatureSupport } from "@/lib/feature-detect"
 import type { QrExportOptions } from "@/qr/export-image"
@@ -334,61 +333,11 @@ export const renderQrDataUrl = vi.fn(
   async (payload: string) => `data:image/png;base64,${btoa(payload)}`,
 )
 export const renderQrSvgString = vi.fn(async () => "<svg viewBox='0 0 1 1'/>")
-export const qrByteCapacity = vi.fn(
-  (level: "L" | "M" | "Q" | "H") => ({ L: 2953, M: 2331, Q: 1663, H: 1273 })[level],
-)
-export const payloadFits = vi.fn(
-  (payload: string, level: "L" | "M" | "Q" | "H") =>
-    payload.length <= qrByteCapacity(level),
-)
 export const qrPngBlob = vi.fn<
   (payload: string, options: QrExportOptions) => Promise<Blob>
 >(async () => new Blob(["png"]))
 export const qrSvgBlob = vi.fn(async () => new Blob(["svg"]))
-export const sanitizeQrFileName = vi.fn((name: string) => name.trim() || "qr")
-export const buildExportFileName = vi.fn(
-  (name: string, id: string, ext: "png" | "svg" | "txt") =>
-    `${name}-${id.slice(0, 8)}.${ext}`,
-)
 export const triggerDownload = vi.fn()
-export const exportQrFramePayloads = vi.fn(
-  async (
-    frames: ReadonlyArray<{ frameIndex: number; payload: string }>,
-    options: { outputName: string; size: number; signal?: AbortSignal },
-  ) => {
-    if (frames.length === 0) return
-    if (options.signal?.aborted) return
-    const safeName = sanitizeQrFileName(options.outputName)
-
-    if (frames.length === 1) {
-      const blob = await qrPngBlob(frames[0]!.payload, {
-        ecLevel: "Q",
-        size: options.size,
-      })
-      if (options.signal?.aborted) return
-      triggerDownload(blob, `${safeName}.png`)
-      return
-    }
-
-    const entries: Array<{ name: string; data: Uint8Array }> = []
-    for (const frame of frames) {
-      if (options.signal?.aborted) return
-      const blob = await qrPngBlob(frame.payload, {
-        ecLevel: "Q",
-        size: options.size,
-      })
-      if (options.signal?.aborted) return
-      const data = new Uint8Array(await blob.arrayBuffer())
-      if (options.signal?.aborted) return
-      entries.push({
-        name: `frame-${String(frame.frameIndex + 1).padStart(2, "0")}.png`,
-        data,
-      })
-    }
-    if (options.signal?.aborted) return
-    triggerDownload(storeOnlyZip(entries), `${safeName}-frames.zip`)
-  },
-)
 export const copyTextToClipboard = vi.fn(async () => undefined)
 
 type FakeCameraFailureState = "failed" | "track-ended"

--- a/tests/ui/helpers/module-mocks.ts
+++ b/tests/ui/helpers/module-mocks.ts
@@ -103,6 +103,8 @@ vi.mock("@/qr/export-image", () => ({
   sanitizeQrFileName: fakes.sanitizeQrFileName,
   buildExportFileName: fakes.buildExportFileName,
   triggerDownload: fakes.triggerDownload,
+}))
+vi.mock("@/lib/clipboard", () => ({
   copyTextToClipboard: fakes.copyTextToClipboard,
 }))
 vi.mock("@/qr/export-frames", () => ({

--- a/tests/ui/helpers/module-mocks.ts
+++ b/tests/ui/helpers/module-mocks.ts
@@ -90,25 +90,24 @@ vi.mock("@/qr/payload", async (importOriginal) => ({
   decodePayload: fakes.decodePayload,
   payloadSha256Hex: fakes.payloadSha256Hex,
 }))
+// Capacity, filename, and frame-set export run for real; only rendering and the
+// browser effects (blob creation, download) are faked. The real export loop
+// reaches those fakes through its own import of @/qr/export-image, so a test
+// that needs an export to fail or hang injects at qrPngBlob — never by mocking
+// the exporter, which is what let a second copy of it drift here before.
 vi.mock("@/qr/encode", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/qr/encode")>()),
   renderQrDataUrl: fakes.renderQrDataUrl,
   renderQrSvgString: fakes.renderQrSvgString,
-  qrByteCapacity: fakes.qrByteCapacity,
-  payloadFits: fakes.payloadFits,
 }))
-vi.mock("@/qr/export-image", () => ({
+vi.mock("@/qr/export-image", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/qr/export-image")>()),
   qrPngBlob: fakes.qrPngBlob,
   qrSvgBlob: fakes.qrSvgBlob,
-  sanitizeQrFileName: fakes.sanitizeQrFileName,
-  buildExportFileName: fakes.buildExportFileName,
   triggerDownload: fakes.triggerDownload,
 }))
 vi.mock("@/lib/clipboard", () => ({
   copyTextToClipboard: fakes.copyTextToClipboard,
-}))
-vi.mock("@/qr/export-frames", () => ({
-  exportQrFramePayloads: fakes.exportQrFramePayloads,
 }))
 vi.mock("@/qr/decode", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/qr/decode")>()),

--- a/tests/ui/online-relay.test.tsx
+++ b/tests/ui/online-relay.test.tsx
@@ -21,8 +21,7 @@ vi.mock("@/qr/decode", async (importOriginal) => ({
   warmQrReader,
 }))
 
-vi.mock("@/qr/export-image", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/qr/export-image")>()),
+vi.mock("@/lib/clipboard", () => ({
   copyTextToClipboard: copyText,
 }))
 

--- a/tests/unit/clipboard.test.ts
+++ b/tests/unit/clipboard.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { AppError } from "@/crypto/errors"
+import { copyTextToClipboard } from "@/lib/clipboard"
+
+describe("copyTextToClipboard", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("writes the text through navigator.clipboard", async () => {
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal("navigator", { clipboard: { writeText } })
+    await copyTextToClipboard("payload-text")
+    expect(writeText).toHaveBeenCalledWith("payload-text")
+  })
+
+  it("maps a clipboard failure to AppError STORAGE_FAILED", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn(async () => {
+          throw new Error("denied")
+        }),
+      },
+    })
+    const failure = copyTextToClipboard("x")
+    await expect(failure).rejects.toBeInstanceOf(AppError)
+    await expect(failure).rejects.toMatchObject({ code: "STORAGE_FAILED" })
+  })
+})

--- a/tests/unit/i18n.test.ts
+++ b/tests/unit/i18n.test.ts
@@ -33,32 +33,7 @@ describe("i18n catalog", () => {
     }
   })
 
-  it("pins the reviewed failure and safety copy, and keeps retired keys retired", () => {
-    expect(messages.en).toMatchObject({
-      "errors.WORKER_UNAVAILABLE":
-        "Cryptographic processing could not be performed safely on this device. Reopen the app in a supported browser.",
-      "animatedQr.missing.body":
-        "Missing frames: {indexes}. Recovery is not possible while frames are missing.",
-      "scanner.progress.missingIndex": "Missing frames: {indexes}",
-      "errors.QR_DECODE_PROGRESS_TIMEOUT":
-        "The QR decoding pipeline stopped making progress on this device.",
-      "settings.error.saveFailed":
-        "Settings could not be saved. Check the device storage.",
-      "settings.error.deleteFailed":
-        "Data could not be deleted. Check the device storage.",
-      "hooks.preferences.loadFailed":
-        "Settings could not be loaded. Default values will be used.",
-    })
-    expect(messages.ja).toMatchObject({
-      "animatedQr.missing.body":
-        "欠損フレーム: {indexes}。欠損したままでは復元できません。",
-      "encrypt.toast.autoCleared": "平文と一時結果を自動消去しました",
-      "scanner.progress.missingIndex": "欠損フレーム: {indexes}",
-      "errors.QR_DECODE_PROGRESS_TIMEOUT":
-        "この端末でQR復号パイプラインの進行が停止しました。",
-      "hooks.preferences.loadFailed":
-        "設定を読み込めませんでした。既定値を使用します。",
-    })
+  it("keeps retired keys retired in both locales", () => {
     for (const removedKey of [
       "encrypt.decrypt.imageTitle",
       "settings.hooks.preferences.loadFailed",
@@ -104,28 +79,26 @@ describe("i18n catalog", () => {
     expect(interpolateMessage("unknown={missing}")).toBe("unknown={missing}")
   })
 
-  it("keeps emphasized acknowledgement copy as safe text segments", () => {
+  it("keeps emphasized acknowledgement segments present and HTML-free", () => {
     const segmentKeys = [
       "offlineAck.body.riskPrefix",
       "offlineAck.body.neverReconnect",
       "offlineAck.body.riskSuffix",
       "offlineAck.body.noGuarantee",
     ] satisfies MessageKey[]
-    const japaneseText = segmentKeys.map((key) => messages.ja[key]).join("")
-
-    expect(japaneseText).toBe(
-      "リスクを抑えるには、ネットワークから物理的に遮断し、二度と接続しない専用端末として運用する必要があります。それ以外に、完全に安全にメッセージの暗号化を行う方法はありません。それでも、端末や導入済みコードを含めた完全な安全を本アプリが保証するものではありません。",
-    )
     for (const language of ["en", "ja"] as const) {
       for (const key of segmentKeys) {
-        expect(messages[language][key]).not.toMatch(/<[^>]+>/)
+        expect(messages[language][key].trim().length, key).toBeGreaterThan(0)
+        expect(messages[language][key], key).not.toMatch(/<[^>]+>/)
       }
     }
   })
 
   it("resolves AppError copy with an explicit language", () => {
-    expect(messageFor("STORAGE_FAILED", "en")).toBe("The storage operation failed.")
-    expect(messageFor("STORAGE_FAILED", "ja")).toBe("保存領域の操作に失敗しました。")
+    const key = errorMessageKey("STORAGE_FAILED")
+    expect(messageFor("STORAGE_FAILED", "en")).toBe(messages.en[key])
+    expect(messageFor("STORAGE_FAILED", "ja")).toBe(messages.ja[key])
+    expect(messages.en[key]).not.toBe(messages.ja[key])
   })
 
   it("uses the same language-independent destructive tokens in both locales", () => {

--- a/tests/unit/qr-density-safety.test.ts
+++ b/tests/unit/qr-density-safety.test.ts
@@ -95,7 +95,8 @@ describe("persisted QR range compatibility", () => {
     },
   )
 
-  it("normalizes every historically stored interval integer to the nearest active stop", () => {
+  // 150–3,000 is the append-only boot-readable range, wider than documented history.
+  it("normalizes every boot-readable interval integer to the nearest active stop", () => {
     for (let frameIntervalMs = 150; frameIntervalMs <= 3_000; frameIntervalMs += 1) {
       expect(isBootReadableFrameIntervalMs(frameIntervalMs)).toBe(true)
       const expected =


### PR DESCRIPTION
Round 2 of the artful-simplicity sweep. No production behavior changes: the only runtime edit moves one function between modules verbatim. Everything else deletes duplicated logic, duplicated prose, or a dead type.

Net **−69 lines**.

## What changed and why

**`InnerMessageV2` deleted** (`src/schemas/domain.ts`) — `git grep -nw` found the declaration and nothing else, and the alias has no runtime form, so it cost a reader a lookup and returned nothing. With it gone `SignedMessageV2` stands alone, so the section banner no longer described a discriminated union either.

**`copyTextToClipboard` moved to `src/lib/clipboard.ts`** — clipboard access is a generic browser effect: the body touches no QR type, no encoder, and no download, so a reader hunting it had no reason to open a module named for QR image export. It now sits beside `lib/reload.ts`, the existing home for one-effect DOM wrappers a test needs to mock. Two test mocks moved with it; neither is reachable by typecheck, and leaving either behind would have pointed copy assertions at the real clipboard while still passing.

**The UI harness stopped running a second QR-export implementation** — the shared mock replaced `qrByteCapacity`, `payloadFits`, `sanitizeQrFileName`, and `buildExportFileName` and reimplemented the entire frame-set export loop, against its own stated policy that pure helpers run for real. The copies had already drifted: the fake sanitizer was `name.trim() || "qr"`, so an output name of `multi/ple` produced `multi/ple-frames.zip` where production strips the separator. Now only rendering and the browser effects stay faked; the real exporter reaches them through its own import, so the two encrypt-page tests that need an export to fail or hang inject at `qrPngBlob` instead of replacing the exporter — which also retires a queued-`mockImplementationOnce` hazard this repo already documents.

**`i18n.test.ts` asserts structure instead of prose** — the catalog is the canonical owner of disclosure copy and the `ui-security-copy` freshness unit reconciles it against the security docs by hand. Repeating whole English and Japanese sentences in a logic test made a third copy that no registry governs, and that only ever forced a prose editor to update the same words twice. Key parity, placeholder parity, error-code coverage, HTML-free guarantees, and the destructive tokens all stay.

**The interval test names the range it walks** — the loop covers every integer from 150 through 3,000, which `frame-interval.ts` defines as the append-only *boot-readable* range; the documented *historical* values are the narrower set the registry records. Calling the wide range "historically stored" invites a later reader to treat compatibility surplus as evidence of history, or to narrow it — which would make stored preferences unreadable and force `wipeOnOnline` true.

## The seam fix was proven, not asserted

Before any mock changed, the ZIP test was given the output name `multi/ple` and failed:

```
AssertionError: expected 'multi/ple-frames.zip' to be 'multiple-frames.zip'
```

That is the divergence between the fake and production, made visible. It passes now because the real sanitizer runs.

## Freshness

The `protocol-docs` unit lists five files this branch touches, so its method ran rather than being skipped: spec §5 was read against `domain.ts` (§5 documents the signed map *only* and never claimed a union, so the banner rewrite moved the code toward the spec), and the three UI files' diffs are import lines only, with every clamp, dwell, and cadence constant unchanged context.

The method turned up two wrong cross-references, fixed here rather than stamped over — neither introduced by this branch:

- `domain.ts` pointed `messageId` at a spec **§G**; the spec has sections 1–10 and `§G` appears nowhere in `docs/`.
- The registry located the messageId note at `~169–170`; it is at 259–264, and line 169 is a different section entirely.

Invariant entries were verified, never stamped.

## Verification

| Gate | Result |
|---|---|
| `make check` | exit 0 — **1006 tests, 74 files**, lint 0 errors |
| `aube run test:e2e` | **31 passed** |
| `protocol-docs` verify | `test:pq` 172/172, boot-controller 69/69 |
| `vocabulary-single-active` (verify-only) | typecheck + `test:pq` pass |
| `display-preference-*` (verify-only) | 117/117 |

`downloads.spec.ts` is the load-bearing one: it drives real ZIP production in a browser, which is exactly the path the harness change affects.

## Review provenance

Three independent readings backed the clipboard boundary move, which the artful-simplicity skill requires two of: the audit, plus two plan reviews that each concurred, the second explicitly without relying on the first. Both reviews' blocking findings are in the shipped plan.

## One deviation from the plan

The planned non-consecutive-frame-index UI test was dropped. `animated-qr-frames.tsx:456` disables Download whenever a frame is missing, so a gapped set is unexportable from that layer by design; "protocol frame index, not array position" stays pinned in `tests/unit/qr-frame-export.test.ts`, where a gap can actually be constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
