### PR TITLE
fix(e2e): stop the relay header snapshot hanging on a closed service worker

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -634,9 +634,11 @@ jobs:
             http://127.0.0.1:4173/nonexistent/spa/route
           cmp "$fallback_body" "$document_root/index.html"
 
-          # Reuse the header-aware reference server instead of Playwright's
-          # build-and-preview command, so tests exercise the archived bytes.
-          env -u CI aube run test:e2e
+          # Playwright boots its own build-and-serve on a cwd-derived port (see
+          # playwright.config.ts); the :4173 server above backs the header checks
+          # against the archived bytes only. Keep CI set — it is what gives this
+          # job the retry budget and the in-band global timeout.
+          aube run test:e2e
 
       - name: Upload unsigned release payload
         id: upload-package

--- a/tests/e2e/online-relay.spec.ts
+++ b/tests/e2e/online-relay.spec.ts
@@ -23,27 +23,22 @@ interface ObservedRequest {
   url: string
 }
 
-async function requestObservation(request: Request): Promise<ObservedRequest> {
+// Synchronous by design. `headersArray()` round-trips through the request's
+// worker, and Chromium terminates an idle service worker well before the test
+// reads what it collected, leaving that promise unsettled until the test times
+// out. The synchronous snapshot carries every header the app itself can set,
+// which is the whole of what the payload-leak assertion inspects.
+function requestObservation(request: Request): ObservedRequest {
   return {
     body: request.postData(),
     fromServiceWorker: request.serviceWorker() !== null,
-    headers: await request.headersArray(),
+    headers: Object.entries(request.headers()).map(([name, value]) => ({
+      name,
+      value,
+    })),
     method: request.method(),
     url: request.url(),
   }
-}
-
-async function awaitRequestObservations(
-  pending: readonly Promise<ObservedRequest>[],
-): Promise<ObservedRequest[]> {
-  const requests: ObservedRequest[] = []
-  let next = 0
-  while (next < pending.length) {
-    const batch = pending.slice(next)
-    next += batch.length
-    requests.push(...(await Promise.all(batch)))
-  }
-  return requests
 }
 
 function expectAllowedRelayRequest(request: ObservedRequest): void {
@@ -268,10 +263,10 @@ test("relays a canonical sym-message frame without relay-payload persistence or 
   }
 
   const relayPayloadMarker = "RELAY_E2E_PAYLOAD_MARKER_7f9c2a"
-  const pendingRequestObservations: Promise<ObservedRequest>[] = []
+  const observedRequests: ObservedRequest[] = []
   const consoleValues: string[] = []
   context.on("request", (request) =>
-    pendingRequestObservations.push(requestObservation(request)),
+    observedRequests.push(requestObservation(request)),
   )
   page.on("console", (message) => consoleValues.push(message.text()))
   page.on("pageerror", (error) => consoleValues.push(error.message))
@@ -421,9 +416,12 @@ test("relays a canonical sym-message frame without relay-payload persistence or 
     expectNoRelayPayloadText([value], relayPayloadMarkers)
   }
   await assertNoRelayPayloadPersistence(page, relayPayloadMarkers)
-  const requests = await awaitRequestObservations(pendingRequestObservations)
-  expect(requests.some(({ fromServiceWorker }) => fromServiceWorker)).toBe(true)
-  for (const request of requests) {
+  expect(observedRequests.some(({ fromServiceWorker }) => fromServiceWorker)).toBe(
+    true,
+  )
+  // An empty snapshot would make the header assertion below pass vacuously.
+  expect(observedRequests.every(({ headers }) => headers.length > 0)).toBe(true)
+  for (const request of observedRequests) {
     expectAllowedRelayRequest(request)
     expectNoRelayPayloadText(
       [


### PR DESCRIPTION
Fixes the `Release main build` failure in [run 31093631464](https://github.com/transparent-pegasus/qr-crypt/actions/runs/31093631464).

## What failed

```
✘ 22 [mobile-chromium] › tests/e2e/online-relay.spec.ts:241:1 › relays a canonical sym-message frame … (3.0m)
  Test timeout of 180000ms exceeded.
  Error: request.headersArray: Worker closed
    at requestObservation (tests/e2e/online-relay.spec.ts:30:28)
```

## Root cause

`requestObservation` awaited `request.headersArray()` inside the `context.on("request")` handler. That call round-trips through the request's worker; Chromium terminates an idle service worker well before the test reads the observations it accumulated, so the promise for a service-worker request never settles. The test blocked on it at the collection point and ran out its full `test.setTimeout(180_000)`. The absence of a pending-call log after the timeout line confirms the block was plain JS rather than a Playwright call — teardown then rejected the stranded promise, which is where `Worker closed` comes from.

`request.headers()` needs no round trip and carries every header the app itself can set, which is the whole of what `expectNoRelayPayloadHeaders` inspects. It cannot hang and cannot reject. The observations stop being promises, so `awaitRequestObservations` has nothing left to drain and is deleted. An explicit non-empty assertion keeps the header check from passing vacuously if that snapshot ever comes back empty.

The synchronous snapshot omits UA/network-added headers (cookie and `sec-*`), which the app has no way to write a relay payload into, so the leak assertion keeps its teeth.

## Second commit: why CI passed and Release failed on the same SHA

`env -u CI` on the release job's e2e step was added when `playwright.config.ts` read `reuseExistingServer: !process.env.CI` — unsetting `CI` was how Playwright was told to reuse the reference server the step had already started. f4c940d hardcoded `reuseExistingServer: false` and derived the port from `cwd`, which left the override with only its side effects: `process.env.CI` now feeds nothing but `retries` and `globalTimeout`, so the release job ran e2e at `retries: 0, globalTimeout: 0` while `CI` [31093631744](https://github.com/transparent-pegasus/qr-crypt/actions/runs/31093631744) ran the same commit at `retries: 2` and passed. `globalTimeout: 0` also means an e2e hang gets killed by the 45-minute job timeout with no Playwright report — the exact case the config comment warns about.

## Flagged, not fixed

The same f4c940d also broke what that step's name claims. It serves the extracted archive on `:4173`, but Playwright now builds `dist` from source on its own cwd-derived port, so **the release job no longer e2e-tests the packaged bytes** — only the `curl` header checks above still hit the archive. Restoring it needs an opt-in reuse flag in `playwright.config.ts`, which touches the worktree-isolation invariant f4c940d deliberately established and bears on a supply-chain property, so it wants its own review rather than a ride on a flake fix. The step comment now states the current behaviour instead of the old claim.

## Verification

Run in a worktree off `origin/dev`:

- `aube run typecheck` — clean
- `aube run lint` — 0 errors (16 pre-existing `react-refresh` warnings)
- `aube run test` — 74 files, 1006 tests passed
- `aube run test:e2e` — 31 passed; the previously hanging test now takes 7.7s
- `actionlint` over `.github/workflows/*.yml` — clean
- ci-actions unit tests (`serve-dist`, `release-tag-read`, `generate-install-txt`, `workflow-action-pins`) — 27 passed

Both touched files are listed in `.claude/skills/freshness/targets.yaml` (`ci-actions`, and the security-review unit). Their executable verify contracts were run and pass, but `last_checked` is deliberately **not** stamped on either: this change performs neither unit's method (no action-major/advisory/cosign review, no security-review refresh), and stamping would falsely claim it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)