### PR TITLE
fix: shrink relay action labels to fit the three-across grid

### DIFF
--- a/src/components/online-relay.tsx
+++ b/src/components/online-relay.tsx
@@ -535,7 +535,7 @@ export function OnlineRelay({
             <Button
               type="button"
               variant="outline"
-              className="h-11 cursor-pointer focus-visible:ring-2"
+              className="h-11 cursor-pointer text-xs focus-visible:ring-2"
               disabled={!cameraAvailable}
               onClick={() => void openDialog("capture")}
             >
@@ -545,7 +545,7 @@ export function OnlineRelay({
             <Button
               type="button"
               variant="outline"
-              className="h-11 cursor-pointer focus-visible:ring-2"
+              className="h-11 cursor-pointer text-xs focus-visible:ring-2"
               onClick={() => void openDialog("playback")}
             >
               <QrCode aria-hidden="true" />
@@ -554,7 +554,7 @@ export function OnlineRelay({
             <Button
               type="button"
               variant="outline"
-              className="h-11 cursor-pointer focus-visible:ring-2"
+              className="h-11 cursor-pointer text-xs focus-visible:ring-2"
               disabled={!cameraAvailable}
               onClick={() => void openDialog("image")}
             >


### PR DESCRIPTION
## What

`text-xs` on the three relay action buttons (`QR → Text` / `Text → QR` / `QR → QR`) in `src/components/online-relay.tsx`.

## Why

Those buttons live in a `sm:grid-cols-3` track that is ~125px wide inside the `max-w-md` online-gate column. At `text-sm`, the Japanese labels (`QR → テキスト`, `テキスト → QR`) plus the leading icon overrun that track, so the horizontal padding collapses and the label crowds the button edges.

`text-xs` is already the button system's small-label size (`Button size="sm"` in `src/components/ui/button.tsx`), and is used on buttons elsewhere (`key-detail/identity-details.tsx`), so this reuses the existing scale rather than adding one.

## Verification

- `make check` — typecheck, lint (0 errors, 13 pre-existing warnings), 1056 unit/integration/UI tests pass
- `aube run test:e2e -- tests/e2e/layout.spec.ts tests/e2e/online-relay.spec.ts` — 11 passed

Freshness: `src/components/online-relay.tsx` is a listed target, but this change touches no documented contract in that unit (replay cadence, absent compatibility switch, relay allowlist) — no refresh, no stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)