### PR TITLE
fix(test): drop the wipe-toggle render race in keys-settings

### DIFF
--- a/tests/ui/keys-settings.test.tsx
+++ b/tests/ui/keys-settings.test.tsx
@@ -748,8 +748,10 @@ describe("settings v2", () => {
       name: "Reset local data after confirmed online connectivity",
     })
 
+    // The hook paints the fail-safe default (on) before the stored preference
+    // loads, so wait for that load instead of asserting the first frame.
+    expect(await screen.findByText("Local data will remain")).toBeInTheDocument()
     expect(wipe).not.toBeChecked()
-    expect(screen.getByText("Local data will remain")).toBeInTheDocument()
 
     await user.click(wipe)
 


### PR DESCRIPTION
## Problem

Unit tests failed on the release PR (#99): `tests/ui/keys-settings.test.tsx > settings v2 > re-enabling writes immediately without a dialog and keeps later disarm guarded`

```
Error: expect(element).not.toBeChecked()
Received element is checked:
  <button aria-checked="true" id="wipe-on-online" ... />
 ❯ tests/ui/keys-settings.test.tsx:751:22
```

## Root cause

`usePreferences` seeds state with `defaultPreferences` (`wipeOnOnline: true`, the fail-safe default) and swaps in the stored value from an async `getPreferences()`. The switch therefore exists — checked — on the very first frame.

The test set `fakePreferences.wipeOnOnline = false`, then `await screen.findByRole("switch", ...)`, which resolved on that first frame, and asserted `not.toBeChecked()` synchronously. Whether the load had landed by then was pure timing. CI lost the race.

Product code is correct: defaulting the switch to on while preferences load is the fail-safe behaviour, so only the test moves.

## Fix

Gate the assertion on the `"Local data will remain"` alert, which renders only under `!preferences.wipeOnOnline` — i.e. only after the stored preference has landed.

## Verification

`aube run test -- --maxWorkers=2` (the exact CI command):

```
 Test Files  76 passed (76)
      Tests  1056 passed (1056)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)