### PR TITLE
Add agents skills link

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## What changed

Adds the `.agents/skills` symlink to the repository's shared agent skills.

## Why

Makes the agent skill directory available through the expected `.agents` path.

## Validation

Verified the commit and pushed branch successfully.