### PR TITLE
fix: move modal padding inside the scroll container

### DIFF
--- a/.claude/skills/freshness/targets.yaml
+++ b/.claude/skills/freshness/targets.yaml
@@ -355,7 +355,7 @@ units:
   - id: protocol-docs
     category: docs
     cadence_days: 90 # also on any protocol/boot change
-    last_checked: 2026-08-16
+    last_checked: 2026-08-21
     files:
       - docs/spec/qr-protocol-v2.md
       - docs/spec/boot-and-reset-v2.md

--- a/src/components/key-detail-dialog.tsx
+++ b/src/components/key-detail-dialog.tsx
@@ -469,12 +469,13 @@ export function KeyDetailContent({
   return (
     <>
       <NoAutofocusDialogContent
-        className="grid max-h-[95dvh] max-w-lg grid-rows-[minmax(0,1fr)] overflow-hidden"
+        className="grid max-h-[95dvh] max-w-lg grid-rows-[minmax(0,1fr)] overflow-hidden p-0 py-6"
         aria-busy={busy}
         aria-hidden={fullscreenOpen || undefined}
         inert={fullscreenOpen || undefined}
       >
-          <div className="grid min-h-0 gap-4 overflow-y-auto pb-14">
+        <div className="min-h-0 overflow-y-auto">
+          <div className="grid gap-4 px-6 pb-14">
             <DialogHeader>
               <DialogTitle>
                 {view.kind === "identity-qr"
@@ -603,6 +604,7 @@ export function KeyDetailContent({
               </div>
             )}
           </div>
+        </div>
       </NoAutofocusDialogContent>
 
       {qrHost &&

--- a/src/components/online-relay.tsx
+++ b/src/components/online-relay.tsx
@@ -613,8 +613,9 @@ export function OnlineRelay({
           if (!open) endSession("close")
         }}
       >
-        <DialogContent className="grid max-h-dvh grid-rows-[minmax(0,1fr)] overflow-hidden pt-[calc(1.5rem+env(safe-area-inset-top))] pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
-          <div className="grid min-h-0 gap-4 overflow-y-auto pb-14">
+        <DialogContent className="grid max-h-dvh grid-rows-[minmax(0,1fr)] overflow-hidden p-0 pt-[calc(1.5rem+env(safe-area-inset-top))] pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
+          <div className="min-h-0 overflow-y-auto">
+            <div className="grid gap-4 px-6 pb-14">
             <DialogHeader>
               <DialogTitle>
                 {t(
@@ -755,6 +756,7 @@ export function OnlineRelay({
                 </Button>
               </div>
             )}
+            </div>
           </div>
         </DialogContent>
       </Dialog>
@@ -765,8 +767,9 @@ export function OnlineRelay({
           if (!open) endSession("close")
         }}
       >
-        <DialogContent className="grid max-h-dvh grid-rows-[minmax(0,1fr)] overflow-hidden pt-[calc(1.5rem+env(safe-area-inset-top))] pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
-          <div className="grid min-h-0 gap-4 overflow-y-auto pb-14">
+        <DialogContent className="grid max-h-dvh grid-rows-[minmax(0,1fr)] overflow-hidden p-0 pt-[calc(1.5rem+env(safe-area-inset-top))] pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
+          <div className="min-h-0 overflow-y-auto">
+            <div className="grid gap-4 px-6 pb-14">
             <DialogHeader>
               <DialogTitle>{t("relay.playback.title")}</DialogTitle>
               <DialogDescription>{t("relay.playback.description")}</DialogDescription>
@@ -830,6 +833,7 @@ export function OnlineRelay({
                 </p>
               </div>
             )}
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/components/qr-scanner-modal.tsx
+++ b/src/components/qr-scanner-modal.tsx
@@ -274,7 +274,7 @@ export function QrScannerModal(props: QrScannerModalProps) {
         <DialogContent
           ref={contentRef}
           tabIndex={-1}
-          className="grid max-h-[95dvh] max-w-lg grid-rows-[auto_minmax(0,1fr)] overflow-hidden p-4"
+          className="grid max-h-[95dvh] max-w-lg grid-rows-[auto_minmax(0,1fr)] overflow-hidden p-0 py-4"
           onOpenAutoFocus={(event) => {
             event.preventDefault()
             contentRef.current?.focus()
@@ -289,9 +289,9 @@ export function QrScannerModal(props: QrScannerModalProps) {
           {/* 4rem prior chrome + ~44px close row + 1rem grid gap */}
           <div
             data-qr-scanner-scroll-region
-            className="min-h-0 max-h-[calc(95dvh-4rem)] overflow-y-auto pb-14"
+            className="min-h-0 max-h-[calc(95dvh-4rem)] overflow-y-auto"
           >
-            {open && panel}
+            <div className="px-4 pb-14">{open && panel}</div>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/pages/decrypt-page.tsx
+++ b/src/pages/decrypt-page.tsx
@@ -426,8 +426,9 @@ export function DecryptPage() {
           if (!open) clearDecrypted()
         }}
       >
-        <NoAutofocusDialogContent className="grid max-h-[95dvh] max-w-lg grid-rows-[minmax(0,1fr)] overflow-hidden">
-          <div className="grid min-h-0 gap-4 overflow-y-auto pb-14">
+        <NoAutofocusDialogContent className="grid max-h-[95dvh] max-w-lg grid-rows-[minmax(0,1fr)] overflow-hidden p-0 py-6">
+          <div className="min-h-0 overflow-y-auto">
+            <div className="grid gap-4 px-6 pb-14">
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 <CheckCircle2 aria-hidden="true" className="size-4 text-success" />
@@ -549,6 +550,7 @@ export function DecryptPage() {
                 </p>
               </>
             )}
+            </div>
           </div>
         </NoAutofocusDialogContent>
       </Dialog>

--- a/src/pages/encrypt-page.tsx
+++ b/src/pages/encrypt-page.tsx
@@ -491,8 +491,9 @@ export function EncryptPage() {
           setResultError(null)
         }}
       >
-        <NoAutofocusDialogContent className="grid max-h-[95dvh] max-w-lg grid-rows-[minmax(0,1fr)] overflow-hidden">
-          <div className="grid min-h-0 gap-5 overflow-y-auto pb-14">
+        <NoAutofocusDialogContent className="grid max-h-[95dvh] max-w-lg grid-rows-[minmax(0,1fr)] overflow-hidden p-0 py-6">
+          <div className="min-h-0 overflow-y-auto">
+            <div className="grid gap-5 px-6 pb-14">
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 <CheckCircle2 aria-hidden="true" className="size-4 text-success" />
@@ -666,6 +667,7 @@ export function EncryptPage() {
                 </Card>
               </>
             )}
+            </div>
           </div>
         </NoAutofocusDialogContent>
       </Dialog>

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -900,7 +900,11 @@ export async function expectStableTrailingDialogClose(
     // An absolutely positioned close sits over the scroll body's padded tail, so
     // overlapping the body BOX is expected and harmless. What must never happen is
     // overlapping actual content, so measure against the body's last element child.
-    const lastContent = scrollRegion.lastElementChild
+    const contentHost =
+      scrollRegion.children.length === 1 && scrollRegion.firstElementChild !== null
+        ? scrollRegion.firstElementChild
+        : scrollRegion
+    const lastContent = contentHost.lastElementChild
     const contentAtTop = lastContent === null ? scrollAtTop : rectOf(lastContent)
     const closeOverlapsBody =
       closeAtTop.left < contentAtTop.right &&

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -46,7 +46,10 @@ interface DialogScrollMetrics {
 async function dialogScrollMetrics(dialog: Locator): Promise<DialogScrollMetrics> {
   return dialog.evaluate((root) => {
     const surface = root as HTMLElement
-    const scrollRegion = Array.from(surface.querySelectorAll<HTMLElement>("*"))
+    // Direct children only: a nested payload scroller (encrypt-page.tsx:562)
+    // would otherwise win the sort once its own overflow grew past the modal's.
+    const scrollRegion = Array.from(surface.children)
+      .filter((element): element is HTMLElement => element instanceof HTMLElement)
       .filter((element) => {
         const style = getComputedStyle(element)
         return (

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -25,6 +25,75 @@ async function expectInsideViewport(
   )
 }
 
+interface DialogScrollMetrics {
+  childCount: number
+  clientHeight: number
+  clientWidth: number
+  hasScannerAttribute: boolean
+  regionWidth: number
+  scrollHeight: number
+  scrollTop: number
+  scrollWidth: number
+  surfaceInnerWidth: number
+  surfacePaddingBottom: number
+  surfacePaddingLeft: number
+  surfacePaddingRight: number
+  surfacePaddingTop: number
+  wrapperPaddingLeft: number | null
+  wrapperPaddingRight: number | null
+}
+
+async function dialogScrollMetrics(dialog: Locator): Promise<DialogScrollMetrics> {
+  return dialog.evaluate((root) => {
+    const surface = root as HTMLElement
+    const scrollRegion = Array.from(surface.querySelectorAll<HTMLElement>("*"))
+      .filter((element) => {
+        const style = getComputedStyle(element)
+        return (
+          /^(auto|scroll)$/u.test(style.overflowY) &&
+          element.scrollHeight > element.clientHeight + 1
+        )
+      })
+      .sort(
+        (left, right) =>
+          right.scrollHeight -
+          right.clientHeight -
+          (left.scrollHeight - left.clientHeight),
+      )[0]
+    if (scrollRegion === undefined) {
+      throw new Error("no scrolling region inside the modal")
+    }
+    const surfaceStyle = getComputedStyle(surface)
+    const wrapper = scrollRegion.firstElementChild
+    const wrapperStyle = wrapper === null ? null : getComputedStyle(wrapper)
+    return {
+      childCount: scrollRegion.children.length,
+      clientHeight: scrollRegion.clientHeight,
+      clientWidth: scrollRegion.clientWidth,
+      hasScannerAttribute: scrollRegion.hasAttribute(
+        "data-qr-scanner-scroll-region",
+      ),
+      regionWidth: scrollRegion.getBoundingClientRect().width,
+      scrollHeight: scrollRegion.scrollHeight,
+      scrollTop: scrollRegion.scrollTop,
+      scrollWidth: scrollRegion.scrollWidth,
+      surfaceInnerWidth: surface.clientWidth,
+      surfacePaddingBottom: Number.parseFloat(surfaceStyle.paddingBottom),
+      surfacePaddingLeft: Number.parseFloat(surfaceStyle.paddingLeft),
+      surfacePaddingRight: Number.parseFloat(surfaceStyle.paddingRight),
+      surfacePaddingTop: Number.parseFloat(surfaceStyle.paddingTop),
+      wrapperPaddingLeft:
+        wrapperStyle === null
+          ? null
+          : Number.parseFloat(wrapperStyle.paddingLeft),
+      wrapperPaddingRight:
+        wrapperStyle === null
+          ? null
+          : Number.parseFloat(wrapperStyle.paddingRight),
+    }
+  })
+}
+
 interface FullscreenLabels {
   close: string
   compatibility: string
@@ -457,23 +526,17 @@ test("keeps the encryption result scrollable and discardable in the narrow viewp
     .locator("p")
     .first()
   const detail = dialog.getByTestId("encrypt-result-detail")
-  const scrollBody = detail.locator("..")
   const close = dialog.getByRole("button", { name: "Close", exact: true })
 
   await expect(payloadText).toHaveText(payload)
-  const overflow = await scrollBody.evaluate((element) => ({
-    clientHeight: element.clientHeight,
-    clientWidth: element.clientWidth,
-    scrollHeight: element.scrollHeight,
-    scrollWidth: element.scrollWidth,
-  }))
+  const overflow = await dialogScrollMetrics(dialog)
   expect(overflow.scrollHeight).toBeGreaterThan(overflow.clientHeight)
   expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth)
   await expectStableTrailingDialogClose(dialog, "Close")
 
   await detail.scrollIntoViewIfNeeded()
   await expect(detail).toBeInViewport()
-  expect(await scrollBody.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
+  expect((await dialogScrollMetrics(dialog)).scrollTop).toBeGreaterThan(0)
   await expectInsideViewport(close, viewport.width, viewport.height, "result close")
   const [dialogBox, closeBox] = await Promise.all([
     dialog.boundingBox(),
@@ -544,4 +607,72 @@ test("fits animated fullscreen QR controls without scrolling in portrait and sho
   ]) {
     await expectAnimatedFullscreenLayout(page, japaneseDetail, viewport, japaneseLabels)
   }
+})
+
+test("keeps modal scroll bodies flush with the surface edge", async ({
+  context,
+  page,
+}) => {
+  await page.setViewportSize({ width: 360, height: 320 })
+  await openOfflineApp(page, context, "/keys")
+  await createSymmetricKey(page, "スクロール検証鍵")
+  await goToOfflinePage(page, "/keys")
+  await page.getByRole("button", { name: /スクロール検証鍵/ }).click()
+
+  const detailDialog = page.getByRole("dialog", { name: "スクロール検証鍵" })
+  await expect(detailDialog).toBeVisible()
+  await detailDialog.evaluate(async (element) => {
+    await Promise.all(
+      element
+        .getAnimations()
+        .map((animation) => animation.finished.catch(() => undefined)),
+    )
+  })
+
+  const detail = await dialogScrollMetrics(detailDialog)
+  // Scrollbar at the surface edge: no horizontal padding outside the scroller.
+  expect(detail.surfacePaddingLeft, "detail surface padding-left").toBe(0)
+  expect(detail.surfacePaddingRight, "detail surface padding-right").toBe(0)
+  expect(
+    Math.abs(detail.regionWidth - detail.surfaceInnerWidth),
+    "detail scroll body spans the surface width",
+  ).toBeLessThanOrEqual(1)
+  // Vertical padding stays on the surface.
+  expect(detail.surfacePaddingTop, "detail surface padding-top").toBe(24)
+  expect(detail.surfacePaddingBottom, "detail surface padding-bottom").toBe(24)
+  // Content keeps its 24px inset, now inside the scrollport, in a sole wrapper.
+  expect(detail.childCount, "detail scroll body child count").toBe(1)
+  expect(detail.wrapperPaddingLeft, "detail content padding-left").toBe(24)
+  expect(detail.wrapperPaddingRight, "detail content padding-right").toBe(24)
+
+  await page.keyboard.press("Escape")
+  await expect(detailDialog).toBeHidden()
+
+  await goToOfflinePage(page, "/keys")
+  await page.getByRole("tab", { name: "Other parties' keys", exact: true }).click()
+  await page.getByRole("button", { name: "Scan a key QR", exact: true }).click()
+  await page.getByRole("button", { name: "Scan a key QR code", exact: true }).click()
+  const scannerDialog = page.getByRole("dialog", { name: "Scan a key QR code" })
+  await expect(scannerDialog).toBeVisible()
+  await scannerDialog.evaluate(async (element) => {
+    await Promise.all(
+      element
+        .getAnimations()
+        .map((animation) => animation.finished.catch(() => undefined)),
+    )
+  })
+
+  const scanner = await dialogScrollMetrics(scannerDialog)
+  expect(scanner.hasScannerAttribute, "scanner scroll region attribute").toBe(true)
+  expect(scanner.surfacePaddingLeft, "scanner surface padding-left").toBe(0)
+  expect(scanner.surfacePaddingRight, "scanner surface padding-right").toBe(0)
+  expect(
+    Math.abs(scanner.regionWidth - scanner.surfaceInnerWidth),
+    "scanner scroll body spans the surface width",
+  ).toBeLessThanOrEqual(1)
+  expect(scanner.surfacePaddingTop, "scanner surface padding-top").toBe(16)
+  expect(scanner.surfacePaddingBottom, "scanner surface padding-bottom").toBe(16)
+  expect(scanner.childCount, "scanner scroll body child count").toBe(1)
+  expect(scanner.wrapperPaddingLeft, "scanner content padding-left").toBe(16)
+  expect(scanner.wrapperPaddingRight, "scanner content padding-right").toBe(16)
 })


### PR DESCRIPTION
## What

Modal vertical scrollbars now sit flush with the modal edge. Six dialog sites had horizontal padding on the dialog surface while a child element did the scrolling, so every scrollbar was inset 24px (16px on the scanner).

Each site now splits three jobs across three elements:

- surface: sizing + **vertical** padding only (`p-0` plus `py-6` / `py-4`, or online-relay's existing `pt`/`pb` safe-area calcs)
- scroll container: `min-h-0 overflow-y-auto` (scanner also keeps `max-h` and `data-qr-scanner-scroll-region`)
- new inner wrapper, the scroller's sole child: `grid gap-*`, horizontal padding, `pb-14`

Padding on an inner child also avoids the engine quirk where padding at the end of a scroll container's own box is dropped.

Sites: `online-relay.tsx` (two dialogs), `key-detail-dialog.tsx`, `qr-scanner-modal.tsx`, `decrypt-page.tsx`, `encrypt-page.tsx`.

## What is deliberately unchanged

- `src/components/ui/dialog.tsx` — three other dialogs scroll on the surface itself and still need the inherited `p-6`; they were already flush.
- The close button (`absolute bottom-3 right-3`). Its overlap with the now-full-height scrollbar track is an accepted decision and stays unasserted.
- Vertical safe-area padding stays on the surface, so content never scrolls under the notch (`design-system/pages/online-gate.md:20` stays true).
- No shared wrapper component: six inline copies, one deliberate scanner variant.

`p-0` + an explicit vertical utility is used rather than `px-0`: `twMerge("p-6", "px-0")` keeps both classes, so `px-0` would win only through Tailwind's emitted utility order. `p-0` is the same conflict group, so the inherited `p-6` is dropped outright.

## Tests

- New e2e `keeps modal scroll bodies flush with the surface edge` pins zero surface inline padding, scroll body width == surface inner width, retained 24/16 surface block padding, sole wrapper, and 24/16 wrapper inline padding, on both the key-detail and scanner dialogs. It was RED on `dev` at `detail surface padding-left` (received 24).
- Repaired `keeps the encryption result scrollable...`: it walked to the scroll body with `detail.locator("..")`, which the new wrapper would have broken. It now resolves the scroller by computed overflow among the surface's direct children.
- `tests/e2e/helpers.ts` descends through the sole content wrapper before measuring close-vs-content overlap.

`make check` (76 files / 1056 tests, typecheck clean, lint 0 errors), `make e2e` (33 passed). Freshness `protocol-docs` verified (179 PQ + 69 boot-controller) and stamped.
