### PR TITLE
fix: refuse fresh-local when the local worktree is not registered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ LOCAL := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/.worktrees/local
 
 .PHONY: fresh-local
 fresh-local:
+	@test -e '$(LOCAL)/.git' \
+		|| { echo 'refusing: $(LOCAL) is not a registered worktree - git and aube would walk up to the main checkout'; exit 1; }
 	@test -z "$$(git -C '$(LOCAL)' status --porcelain --untracked-files=no)" \
 		|| { echo 'refusing: $(LOCAL) has uncommitted changes - commit or discard them first'; exit 1; }
 	git fetch origin $(BRANCH)


### PR DESCRIPTION
## Problem

An empty or missing `.worktrees/local` is not an error for `git` or `aube` — both walk up to the parent repository. `make fresh-local REF=<branch>` then reports success while doing the wrong thing:

- `git -C '$(LOCAL)' checkout --detach origin/$(BRANCH)` detaches the **main checkout**
- `cd '$(LOCAL)' && aube run build` builds `dist/` in the **main root**

Caddy's document root stays empty, and the main checkout is left detached at the requested ref. Observed 2026-08-12, when `.worktrees/local` had been deleted outside the session.

The existing uncommitted-changes check does not catch this: with the main checkout clean, `git -C <missing> status --porcelain` succeeds and the target proceeds.

## Fix

Test for the worktree's own `.git` before anything else.

## Verification

- Registered worktree (current state): `make -n fresh-local` exits 0, guard passes.
- Empty `.worktrees/local` in a scratch copy: the target stops with `Error 1` and prints `refusing: ... is not a registered worktree`, at the point where it previously detached the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHLi2gvNCnF4kBpk6rjTA