### PR TITLE
docs: state the branch-off-dev rule in the repository rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Build fully offline encryption engineered against nation-state cryptanalysis and
 
 # Rules
 
-- No backward compatibility in active paths. Installs never update, so no legacy value, migration, or rollback path. One exception, and only where `.claude/skills/freshness/targets.yaml` invariants already document it: boot-time preference *reads* stay append-only, because a stored value that becomes unreadable forces `wipeOnOnline` true and exposes data to a later network-confirmed wipe. Write paths stay strict.
-- On task completion, follow `.claude/skills/freshness/SKILL.md`: add new time-decaying files to `targets.yaml`; for listed files touched or invalidated, refresh and verify affected units; stamp only passed units; verify, never stamp, invariants.
 - This project's core principles live in two skills: `.claude/skills/artful-simplicity/SKILL.md` for the simplicity bar and `.claude/skills/nation-state-security/SKILL.md` for the threat model.
+- No backward compatibility in active paths. Installs never update, so no legacy value, migration, or rollback path. One exception, and only where `.claude/skills/freshness/targets.yaml` invariants already document it: boot-time preference *reads* stay append-only, because a stored value that becomes unreadable forces `wipeOnOnline` true and exposes data to a later network-confirmed wipe. Write paths stay strict.
+- Branch off `origin/dev` for every change. `dev` is protected, so a direct push is rejected and even a one-line edit goes through a branch and a PR.
+- On task completion, follow `.claude/skills/freshness/SKILL.md`: add new time-decaying files to `targets.yaml`; for listed files touched or invalidated, refresh and verify affected units; stamp only passed units; verify, never stamp, invariants.


### PR DESCRIPTION
`dev` rejects direct pushes under the active branch-protection ruleset. Every change — including a one-line edit — needs a branch and a PR.

That constraint was only carried in agent memory, so a fresh session would learn it by having a push rejected after committing. One line in `# Rules` fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHLi2gvNCnF4kBpk6rjTA