### PR TITLE
chore(eslint): ignore .tmp so scratch scripts do not fail lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default tseslint.config(
       "test-results",
       "node_modules",
       ".worktrees",
+      ".tmp",
     ],
   },
   js.configs.recommended,


### PR DESCRIPTION
`.tmp/` is the gitignored scratch and delegated-report directory, but eslint still linted it. A stray `.mjs` left there makes `aube run lint` fail in the main checkout with errors unrelated to the tree under review — and since `make check` runs lint, the failure looks like a regression in the branch.

`.worktrees` is already in `ignores` for the same reason; `.tmp` was missed.

## Verification

Dropped a deliberately broken `.tmp/lint-probe.mjs`:

- before: `✖ 15 problems (2 errors, 13 warnings)` — both errors from the probe
- after: `✖ 13 problems (0 errors, 13 warnings)` — pre-existing warnings unchanged

Probe removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEHLi2gvNCnF4kBpk6rjTA