### PR TITLE
docs: clarify artful simplicity guidance

### DIFF
--- a/.claude/skills/artful-simplicity/SKILL.md
+++ b/.claude/skills/artful-simplicity/SKILL.md
@@ -1,23 +1,16 @@
 ---
 name: artful-simplicity
-description: Audit code, tests, and prose for artful simplicity; use for design, over-engineering, and redundancy reviews.
+description: Audit code, tests, and prose for artful simplicity; use for readability, design, refactoring, over-engineering, and redundancy reviews.
 ---
 
 # Artful simplicity
 
-A unit is simple when a cold reader can name its one idea, predict its contents
-from its name, and keep nothing unrelated in mind. Tests cover only logic; prose
-says only what is needed.
+A unit is simple when a cold reader can name its one idea, predict its contents from its name, and keep nothing unrelated in mind. Tests state observable behavior and invariants; prose spends exactly the words it needs.
 
-Local reading judges clarity, not necessity. It may justify `rewrite`; `delete`,
-`fold`, and boundary moves remain hypotheses. Evidence required: for deletion,
-repository-wide reachability, freshness/invariant protection, and security
-consequence; for folding, equivalence across every observable state and
-transition—including pending, already-resolved, cancellation, close/reopen, and
-error; for boundaries, convergence of at least two independent readings.
+Local reading judges clarity, not necessity. Rewrite may follow from sight only if no observer sees behavior change; delete, fold, and move require, respectively, proof of reachability and consequence, equivalence across observable states and transitions, and independent agreement on the boundary. Seek contradictions, not volume.
 
-Seek contradictions, not volume. Before behavior changes, state the change,
-reachable observer, safety direction, and what the opposite choice breaks.
-Direction decides, not size.
+Before changing behavior, name the change, the observer, the safety direction, and the broken alternative. Direction decides, not size.
 
 Exclude append-only/frozen targets in `../freshness/targets.yaml`.
+
+

--- a/.claude/skills/artful-simplicity/SKILL.md
+++ b/.claude/skills/artful-simplicity/SKILL.md
@@ -12,5 +12,3 @@ Local reading judges clarity, not necessity. Rewrite may follow from sight only 
 Before changing behavior, name the change, the observer, the safety direction, and the broken alternative. Direction decides, not size.
 
 Exclude append-only/frozen targets in `../freshness/targets.yaml`.
-
-

--- a/.claude/skills/artful-simplicity/SKILL.md
+++ b/.claude/skills/artful-simplicity/SKILL.md
@@ -7,7 +7,7 @@ description: Audit code, tests, and prose for artful simplicity; use for readabi
 
 A unit is simple when a cold reader can name its one idea, predict its contents from its name, and keep nothing unrelated in mind. Tests state observable behavior and invariants; prose spends exactly the words it needs.
 
-Local reading judges clarity, not necessity. Rewrite may follow from sight only if no observer sees behavior change; delete, fold, and move require, respectively, proof of reachability and consequence, equivalence across observable states and transitions, and independent agreement on the boundary. Seek contradictions, not volume.
+Local reading judges clarity, not necessity. Rewrite may follow from sight only if no observer sees behavior change; delete, fold, and move require, respectively, proof of reachability and proof of reachability and of behavioral and security consequences, equivalence across observable states and transitions, and independent agreement on the boundary. Seek contradictions, not volume.
 
 Before changing behavior, name the change, the observer, the safety direction, and the broken alternative. Direction decides, not size.
 


### PR DESCRIPTION
## Summary
- clarify the artful simplicity skill's readability and behavior-observer guidance
- preserve the existing freshness-target exclusion and decision criteria

## Verification
- git diff --check