### PR TITLE
docs: translate design-system archive into English (Wave 7)

### DIFF
--- a/design-system/MASTER.md
+++ b/design-system/MASTER.md
@@ -1,53 +1,53 @@
 # QR Crypt — Design System MASTER
 
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](README.md) を参照してください。現行実装は [ソース](../src/)・[テスト](../tests/)、契約は [QR プロトコル仕様](../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../src/) and [Tests](../tests/); for its contracts, see the [QR protocol specification](../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../docs/spec/boot-and-reset-v2.md).
 
-以下は ui-ux-pro-max-skill の生成結果(`design-system/offline-cipher/MASTER.md`、検索クエリは spec §5 の 3 件)を、本アプリの制約(外部フォント禁止・オフライン・日本語 UI・モバイルファースト)へ適合させ、その後の改訂も含めて保存した設計記録です。
-当時はページ別文書を優先し、独自の色・余白トークンを追加しない方針でした。これらの優先関係や以下の規則は歴史的な記録であり、現行実装を規定しません。
+This design record preserves the ui-ux-pro-max-skill output (`design-system/offline-cipher/MASTER.md`, using the 3 search queries from spec §5), adapted to the app's constraints (no external fonts, offline operation, Japanese UI, and mobile-first design), together with subsequent revisions.
+At the time, page-specific documents took precedence, and no custom color or spacing tokens were to be added. That precedence and the rules below are historical records and do not govern the current implementation.
 
-## 0. 生成結果からの意図的変更
+## 0. Intentional changes from the generated output
 
-| 生成結果 | 当時の採用内容 | 理由 |
+| Generated output | Choice adopted at the time | Reason |
 |---|---|---|
-| JetBrains Mono (Google Fonts) | システムフォントスタック | spec §17/§18 が外部フォント・CDN を禁止。日本語グリフ対応 |
-| 全文モノスペース | UI 本文=サンセリフ、技術データ=モノスペース | 日本語本文の可読性。terminal/precision の気分は データ表示で維持 |
-| ダーク単一パレット | ライト/ダーク両対応トークン | spec §6 ダークモード対応 + WCAG AA |
-| マーケティング的ページ構成 (Hero/Proof/CTA) | ツール型 1 カラム構成 | 本アプリはユーティリティ PWA。信頼性は明快な警告・状態表示で担保 |
+| JetBrains Mono (Google Fonts) | System font stack | spec §17/§18 prohibits external fonts and CDNs. Support for Japanese glyphs |
+| Monospace throughout | Sans-serif UI body text; monospace technical data | Readability of Japanese body text. Retain the terminal/precision feel in data displays |
+| Dark-only palette | Tokens supporting both light and dark | spec §6 dark mode support + WCAG AA |
+| Marketing page structure (Hero/Proof/CTA) | Single-column tool layout | This app is a utility PWA. Convey trustworthiness through clear warnings and status displays |
 
-## 1. スタイル方針
+## 1. Style direction
 
-**Exaggerated Minimalism(抑制版)**: 高コントラスト、余白広め、装飾なし、太字見出し、要素数最小。
-セキュリティツールとしての「精密さ」はモノスペースのデータ表示・整然としたグリッド・一貫した状態表示で表現する。
-禁止: 遊び感のある装飾、紫/ピンクのAIグラデーション、色のみによる状態表現、絵文字アイコン(アイコンは lucide-react のみ)。
+**Exaggerated Minimalism (restrained)**: high contrast, generous whitespace, no decoration, bold headings, minimal elements.
+Express the "precision" of a security tool through monospace data displays, orderly grids, and consistent status displays.
+Prohibited: playful decoration, purple/pink AI gradients, status conveyed only by color, and emoji icons (use only lucide-react icons).
 
-## 2. カラートークン(shadcn CSS variables へマップ)
+## 2. Color tokens (mapped to shadcn CSS variables)
 
-QR コード表示面だけは例外: **常に白背景 `#FFFFFF`・黒セル `#000000`**(ダークモードでも固定。トークン非適用)。
+The QR code display surface is the sole exception: **always a white background `#FFFFFF` and black cells `#000000`** (fixed even in dark mode; tokens do not apply).
 
 ### Light
 
-| Token | 値 | 用途 |
+| Token | Value | Use |
 |---|---|---|
-| `--background` | `#FFFFFF` | ページ背景 |
-| `--foreground` | `#0F172A` | 本文 |
-| `--card` | `#F8FAFC` | カード面 |
+| `--background` | `#FFFFFF` | Page background |
+| `--foreground` | `#0F172A` | Body text |
+| `--card` | `#F8FAFC` | Card surface |
 | `--card-foreground` | `#0F172A` | |
 | `--popover` / `--popover-foreground` | `#FFFFFF` / `#0F172A` | |
-| `--primary` | `#1E3A5F` | 主ボタン・リンク・選択状態(紺=shield) |
+| `--primary` | `#1E3A5F` | Primary buttons, links, and selected states (navy = shield) |
 | `--primary-foreground` | `#FFFFFF` | |
-| `--secondary` / `--secondary-foreground` | `#E2E8F0` / `#1E293B` | 副ボタン |
-| `--muted` / `--muted-foreground` | `#F1F5F9` / `#475569` | 補助面・補助文字 |
-| `--accent` / `--accent-foreground` | `#DCFCE7` / `#14532D` | ホバー・強調面(green) |
-| `--success` / `--success-foreground` | `#15803D` / `#FFFFFF` | 成功・オンライン(AA 確保) |
-| `--warning` / `--warning-foreground` | `#B45309` / `#FFFFFF` | 機密警告 |
-| `--destructive` / `--destructive-foreground` | `#DC2626` / `#FFFFFF` | 破壊的操作・最高機密 |
+| `--secondary` / `--secondary-foreground` | `#E2E8F0` / `#1E293B` | Secondary buttons |
+| `--muted` / `--muted-foreground` | `#F1F5F9` / `#475569` | Supporting surfaces and text |
+| `--accent` / `--accent-foreground` | `#DCFCE7` / `#14532D` | Hover and emphasis surfaces (green) |
+| `--success` / `--success-foreground` | `#15803D` / `#FFFFFF` | Success and online status (AA compliant) |
+| `--warning` / `--warning-foreground` | `#B45309` / `#FFFFFF` | Sensitive-content warnings |
+| `--destructive` / `--destructive-foreground` | `#DC2626` / `#FFFFFF` | Destructive actions and highly sensitive content |
 | `--border` / `--input` | `#E2E8F0` / `#CBD5E1` | |
-| `--ring` | `#1E3A5F` | フォーカスリング |
+| `--ring` | `#1E3A5F` | Focus ring |
 
 ### Dark
 
-| Token | 値 |
+| Token | Value |
 |---|---|
 | `--background` | `#0F172A` |
 | `--foreground` | `#F8FAFC` |
@@ -63,74 +63,74 @@ QR コード表示面だけは例外: **常に白背景 `#FFFFFF`・黒セル `#
 | `--border` / `--input` | `rgba(255,255,255,0.10)` / `rgba(255,255,255,0.16)` |
 | `--ring` | `#8AB0DE` |
 
-テーマ切替: `documentElement.class` の `dark`。既定は `system`(prefers-color-scheme 追従)。保存先は `localStorage['oc-theme']` のみ。
+Theme switching: `dark` on `documentElement.class`. Default: `system` (follows prefers-color-scheme). Stored only in `localStorage['oc-theme']`.
 
-## 3. タイポグラフィ
+## 3. Typography
 
 ```css
 --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Hiragino Sans", "Noto Sans JP", "Yu Gothic UI", sans-serif;
 --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 ```
 
-| 用途 | スタイル |
+| Use | Style |
 |---|---|
-| ページタイトル (h1) | 1.375rem / 700 / tracking-tight |
-| セクション見出し (h2) | 1.125rem / 600 |
-| 本文 | 0.9375rem / 400 / leading-relaxed |
-| 補助・キャプション | 0.8125rem / `--muted-foreground` |
-| 技術データ(指紋・鍵ID・バイト数・ペイロード) | `--font-mono` / tabular-nums / 0.8125–0.875rem |
+| Page title (h1) | 1.375rem / 700 / tracking-tight |
+| Section heading (h2) | 1.125rem / 600 |
+| Body text | 0.9375rem / 400 / leading-relaxed |
+| Supporting text and captions | 0.8125rem / `--muted-foreground` |
+| Technical data (fingerprints, key IDs, byte counts, payloads) | `--font-mono` / tabular-nums / 0.8125–0.875rem |
 
-鍵指紋は `7392 1840 5521 9074` 形式(4 桁×4、半角スペース区切り、mono、コピー可能)。
+Key fingerprints use the format `7392 1840 5521 9074` (4 groups × 4 digits, separated by ASCII spaces, mono, copyable).
 
-## 4. スペーシング / 形状 / 標高 / z-index
+## 4. Spacing / shape / elevation / z-index
 
-- スペーシング: 4/8/16/24/32/48/64px(`--space-xs..3xl`)。ページ左右パディング 16px。セクション間 24px。
-- 角丸: カード・ダイアログ 12px、ボタン・入力 8px、バッジ 9999px。
-- 影: sm `0 1px 2px rgba(0,0,0,.05)` / md `0 4px 6px rgba(0,0,0,.1)` / lg `0 10px 15px rgba(0,0,0,.1)`(ダークでは影に頼らず border で区切る)。
-- z-index スケール(任意値禁止): ヘッダー `z-20` / 下部ナビ `z-30` / ダイアログ `z-50` / トースト `z-[60]`。
+- Spacing: 4/8/16/24/32/48/64px (`--space-xs..3xl`). Horizontal page padding: 16px. Between sections: 24px.
+- Corner radius: cards and dialogs 12px, buttons and inputs 8px, badges 9999px.
+- Shadows: sm `0 1px 2px rgba(0,0,0,.05)` / md `0 4px 6px rgba(0,0,0,.1)` / lg `0 10px 15px rgba(0,0,0,.1)` (in dark mode, separate elements with borders rather than relying on shadows).
+- z-index scale (no arbitrary values): header `z-20` / bottom navigation `z-30` / dialogs `z-50` / toasts `z-[60]`.
 
-## 5. レイアウト / ナビゲーション
+## 5. Layout / navigation
 
-- 1 カラム、`max-width: 28rem`、中央寄せ。
-- ヘッダー: sticky top、アプリ名(左)+ ネットワーク状態バッジ(右)。`padding-top: env(safe-area-inset-top)`。
-- 本文下端余白: `calc(64px + env(safe-area-inset-bottom) + 16px)`(固定ナビと重なり禁止)。
-- 下部ナビ共通シェル: `position: fixed; left:0; right:0; bottom:0; padding-bottom: env(safe-area-inset-bottom);` 高さ 64px、子要素数にかかわらず等幅。オフラインは 4 項目(暗号化=`LockKeyhole` `/encrypt`、復号=`LockKeyholeOpen` `/decrypt`、鍵=`KeyRound` `/keys`、設定=`Settings` `/settings`)、対象時のオンライン画面は 2 項目(トップ=Home, リレー=MessageSquareText)のアイコンナビ。現在項目: `aria-current="page"` + `--primary` 色 + 上端 2px インジケーター。各項目タップ領域 ≥44×44px。
-- 横スクロール禁止。長いペイロード文字列は `break-all` + `max-h` + スクロール領域。
+- Single column, `max-width: 28rem`, centered.
+- Header: sticky top, app name (left) + network status badge (right). `padding-top: env(safe-area-inset-top)`.
+- Bottom content padding: `calc(64px + env(safe-area-inset-bottom) + 16px)` (must not overlap fixed navigation).
+- Shared bottom navigation shell: `position: fixed; left:0; right:0; bottom:0; padding-bottom: env(safe-area-inset-bottom);`, height 64px, equal-width items regardless of the number of children. Offline icon navigation has 4 items (Encrypt = `LockKeyhole` `/encrypt`, Decrypt = `LockKeyholeOpen` `/decrypt`, Keys = `KeyRound` `/keys`, Settings = `Settings` `/settings`); the online screen, when eligible, has 2 items (Top = Home, Relay = MessageSquareText). Current item: `aria-current="page"` + `--primary` color + a 2px top indicator. Each item's tap target is ≥44×44px.
+- No horizontal scrolling. Long payload strings use `break-all` + `max-h` + a scrollable area.
 
-## 6. コンポーネント規約(shadcn/ui ベース)
+## 6. Component conventions (based on shadcn/ui)
 
-- **タップ対象**: Button、TabsTrigger、SelectTrigger、Label、オフライン確認の raw `<label>`、鍵一覧の raw key-row `<button>`、密度再起動警告の `<summary>` には、表示テキストの長押し選択とダブルタップズーム遅延を防ぐ `select-none touch-manipulation` を常に併記する。鍵行は主要なタップ対象なので鍵名の長押し選択性を意図的に失わせるが、鍵名の閲覧・コピーは詳細ダイアログで行う。非対話的な `buttonVariants` 適用 `role="note"` は `select-text touch-auto` で元に戻す。
-- **Button**: 高さ 44px(`size="lg"` 相当を既定)。primary=主操作(暗号化・生成)、secondary=補助、destructive=削除系、ghost=行内操作。アイコンのみボタンは 44×44 + `aria-label` 必須。`cursor-pointer`、遷移 150–200ms、`hover:opacity-90`。レイアウトが動く transform ホバー禁止。
-- **Card**: 面=`--card`、区切りは border 優先。ホバーで浮かせない(ツール UI。リスト行のみ `hover:bg-accent`)。
-- **Input/Textarea**: 高さ 44px(Textarea は min-h 120px)、フォントサイズ 16px(iOS ズーム防止)、`focus-visible:ring-2 ring-[--ring] ring-offset-2`。ラベルは `htmlFor` で必ず関連付け(placeholder をラベル代わりにしない)。
-- **Dialog / AlertDialog**: 破壊的・不可逆操作は必ず AlertDialog で確認(直接実行禁止)。確認強度 3 段階: (1) 通常=確認ボタン、(2) 強=「リスクを理解しました」チェックボックスで確認ボタン活性化、(3) 最強=「全削除」の完全一致入力で活性化。destructive ボタンは右側。Esc/オーバーレイで安全側へ閉じる。
-- **Badge(機密度)**: 公開=`secondary`+Globe / 機密=`--warning` 面+ShieldAlert / 最高機密=`--destructive` 面+TriangleAlert。**必ずアイコン+テキスト併記**(色のみ禁止)。最高機密は一覧・詳細で常時表示。
-- **ネットワーク状態バッジ**: オンライン=`--success` ドット+「オンライン」/ オフライン=`--muted-foreground` ドット+「オフライン」。**安全性の主張をしない**(「オフラインなので安全」等の文言禁止、spec §2)。
-- **トースト(sonner)**: 暗黙の設定自動保存には成功トーストを出さず、コントロールが表示する新しい値をフィードバックとする。エラーはインライン `role="alert"`(アイコン+文言)を優先し、QR の全画面ダイアログ中はインライン alert が覆われるため、互換モード設定ペアの保存失敗に限りエラートーストを補助してよい。この非対称性は意図的である。
-- **QR 表示**: 白面パネル(padding 16px、白 `#FFFFFF` 固定、border `#E2E8F0`、rounded 12px)。サイズ既定 512px・`max-width:100%`。全画面は白全面・四辺 safe-area 対応・`h-dvh overflow-hidden` とし、QR は残り領域内で `max-height:100%; width:auto; object-fit:contain`。全画面内の `Button` は `border-slate-300`、44×44px以上とする。
-  - 単一画像 QR は操作列とカウンターを置かず、QR の下に左寄せのアイコンのみ全画面ボタンを置く。全画面面は QR と右寄せのアイコンのみ閉じるボタンだけを表示する。
-  - 複数 QR の非全画面面は **QR → カウンター → 1 行の操作列(前へ / 一時停止・再生 / 次へ / ラベル付き互換モード / 全画面) → 1 個のダウンロードボタン** の順とする。前へ・一時停止/再生・次へ・全画面は44×44pxのアイコンのみボタンとし、移動/再生ボタンの名前は `sr-only` で保つ。全画面面も QR → カウンター → 同じ1行とし、末尾だけを閉じるボタンに置き換える。
-  - 互換モードは `1000 B / 200 ms` と `100 B / 2000 ms` の固定ペアを切り替える1個のスイッチで、密度と速度は個別調整できない。`/settings` にも調整 UI を置かない。データサイズ・EC レベル行と輝度ヒントは表示しない。
+- **Tap targets**: always pair `select-none touch-manipulation` on Button, TabsTrigger, SelectTrigger, Label, the raw `<label>` for offline acknowledgement, the raw key-row `<button>` in the key list, and the `<summary>` for the density restart warning, to prevent long-press text selection and the double-tap zoom delay. Key rows are primary tap targets, so long-press selection of key names is deliberately disabled; names can be viewed and copied in the detail dialog. Restore `select-text touch-auto` on noninteractive `role="note"` elements styled with `buttonVariants`.
+- **Button**: height 44px (default equivalent to `size="lg"`). primary = main actions (encrypt, generate), secondary = supporting actions, destructive = deletion, ghost = inline actions. Icon-only buttons require 44×44 and an `aria-label`. `cursor-pointer`, 150–200ms transitions, `hover:opacity-90`. No transform hover effects that move the layout.
+- **Card**: surface = `--card`; prefer borders for separation. Do not lift cards on hover (tool UI; only list rows use `hover:bg-accent`).
+- **Input/Textarea**: height 44px (Textarea min-h 120px), font size 16px (prevents iOS zoom), `focus-visible:ring-2 ring-[--ring] ring-offset-2`. Always associate labels with `htmlFor` (do not substitute placeholders for labels).
+- **Dialog / AlertDialog**: always confirm destructive or irreversible actions with AlertDialog (no direct execution). Three confirmation strengths: (1) normal = confirmation button; (2) strong = a checkbox labelled with the historical Japanese phrase meaning "I understand the risks" enables the confirmation button; (3) strongest = exact-match entry of the historical Japanese phrase meaning "delete all" enables it. Both phrases here are English translations of historical Japanese UI text; the latter was not a literal English input token. Place the destructive button on the right. Esc/overlay dismissal takes the safe path.
+- **Badge (sensitivity)**: Public = `secondary` + Globe / Sensitive = `--warning` surface + ShieldAlert / Highly sensitive = `--destructive` surface + TriangleAlert. **Always include both icon and text** (never color alone). Always show the highly sensitive badge in lists and details.
+- **Network status badge**: online = `--success` dot + "Online" / offline = `--muted-foreground` dot + "Offline." **Make no safety claim** (wording such as "Safe because offline" is prohibited, spec §2).
+- **Toasts (sonner)**: do not show success toasts for implicit settings autosave; the new value shown by the control is the feedback. Prefer inline `role="alert"` errors (icon + text). While the fullscreen QR dialog covers inline alerts, an error toast may supplement them only for a failure to save the compatibility-mode settings pair. This asymmetry is intentional.
+- **QR display**: white panel (padding 16px, fixed white `#FFFFFF`, border `#E2E8F0`, rounded 12px). Default size 512px, `max-width:100%`. Fullscreen uses an entirely white surface, safe-area support on all four sides, and `h-dvh overflow-hidden`; within the remaining space, the QR uses `max-height:100%; width:auto; object-fit:contain`. Fullscreen `Button` elements use `border-slate-300` and are at least 44×44px.
+  - For a single-image QR, omit the action row and counter; place a left-aligned, icon-only fullscreen button below the QR. The fullscreen surface shows only the QR and a right-aligned, icon-only close button.
+  - For multiple QRs outside fullscreen, use this order: **QR → counter → one action row (previous / pause-play / next / labelled compatibility mode / fullscreen) → one download button**. Previous, pause/play, next, and fullscreen are 44×44px icon-only buttons; retain navigation/playback button names with `sr-only`. Fullscreen also uses QR → counter → the same single row, replacing only the final button with close.
+  - Compatibility mode is one switch between the fixed pairs `1000 B / 200 ms` and `100 B / 2000 ms`; density and speed cannot be adjusted separately. Do not add adjustment UI to `/settings` either. Do not show the data-size/EC-level row or a brightness hint.
 
-## 7. アクセシビリティ / モーション
+## 7. Accessibility / motion
 
-- セマンティック HTML(`button`/`nav`/`main`/`h1..`)。div+onClick 禁止。
-- フォーカス可視必須: `focus-visible:ring-2`。Tab 順序=視覚順序。
-- 状態表示は アイコン+テキスト(+`aria-live="polite"` のステータス領域)。エラーは `role="alert"`。
-- ダイアログはフォーカストラップ+初期フォーカスは安全側ボタン(radix 既定)。
-- `prefers-reduced-motion: reduce` で transition/animation を実質無効化(グローバル CSS)。
-- コントラスト: 本文 4.5:1 以上(上記トークンは充足)。
+- Semantic HTML (`button`/`nav`/`main`/`h1..`). No div+onClick.
+- Visible focus is mandatory: `focus-visible:ring-2`. Tab order = visual order.
+- Status displays use icon + text (+ a status region with `aria-live="polite"`). Errors use `role="alert"`.
+- Dialogs trap focus and initially focus the safe button (radix default).
+- Effectively disable transitions/animations under `prefers-reduced-motion: reduce` (global CSS).
+- Contrast: at least 4.5:1 for body text (the tokens above meet this).
 
-## 8. 文言トーン
+## 8. Wording and tone
 
-- 丁寧・断定・短文。「〜できます」「〜してください」。
-- 警告は結果を具体的に(「撮影・画面共有・クラウド同期された場合、暗号文を復号される可能性があります」)。
-- エラーは原因候補+次の行動。内部詳細・スタックは出さない。
-- オフライン表示は状態情報であり安全性の保証ではない、という前提を崩す文言を書かない。
+- Polite, definite, short sentences: "You can…" and "Please…"
+- Warnings state concrete consequences ("If photographed, screen-shared, or synced to the cloud, it may allow ciphertext to be decrypted").
+- Errors give possible causes + the next action. Do not expose internal details or stacks.
+- Wording must preserve the premise that an offline indicator reports status and does not guarantee safety.
 
-## 9. 当時のチェックリスト（参考記録）
+## 9. Checklist used at the time (historical reference)
 
-- [ ] 絵文字アイコンなし(lucide のみ) / [ ] クリック要素に cursor-pointer / [ ] ホバー・遷移 150–300ms
-- [ ] ライト・ダーク両方でコントラスト AA / [ ] QR は常に白背景 / [ ] フォーカス可視 / [ ] reduced-motion 対応
-- [ ] 375px で横スクロールなし / [ ] 固定ナビに内容が隠れない / [ ] タッチ領域 44px / [ ] 色のみの状態表現なし
-- [ ] 破壊的操作に確認 / [ ] 最高機密に常時警告 / [ ] `aria-current`・`htmlFor`・`role="alert"` 適用
+- [ ] No emoji icons (lucide only) / [ ] cursor-pointer on clickable elements / [ ] 150–300ms hover effects and transitions
+- [ ] AA contrast in both light and dark / [ ] Always-white QR background / [ ] Visible focus / [ ] reduced-motion support
+- [ ] No horizontal scrolling at 375px / [ ] Fixed navigation does not hide content / [ ] 44px touch targets / [ ] No status conveyed only by color
+- [ ] Confirmation for destructive actions / [ ] Persistent warning for highly sensitive content / [ ] `aria-current`, `htmlFor`, and `role="alert"` applied

--- a/design-system/PROVENANCE.md
+++ b/design-system/PROVENANCE.md
@@ -1,48 +1,48 @@
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](README.md) を参照してください。現行実装は [ソース](../src/)・[テスト](../tests/)、契約は [QR プロトコル仕様](../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../src/) and [Tests](../tests/); for its contracts, see the [QR protocol specification](../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../docs/spec/boot-and-reset-v2.md).
 
-# design-system 生成来歴(ui-ux-pro-max-skill)
+# design-system generation provenance (ui-ux-pro-max-skill)
 
-spec §5「ui-ux-pro-max-skill の使用」の実施記録。
+Record of carrying out spec §5, "Use of ui-ux-pro-max-skill."
 
-## 1. スキルの探索(spec §5 の候補順)
+## 1. Skill discovery (in the candidate order from spec §5)
 
-| 候補 | 結果 |
+| Candidate | Result |
 |---|---|
-| `.claude/skills/ui-ux-pro-max/`(repo) | 無し |
-| `.cursor/skills/ui-ux-pro-max/`(repo) | 無し |
-| `.agents/skills/ui-ux-pro-max/`(repo) | 無し |
-| `.windsurf/skills/ui-ux-pro-max/`(repo) | 無し |
-| `~/.claude/skills/ui-ux-pro-max/` ほか home 直下 | 無し |
-| **ローカル plugin cache** | **発見・採用**: local plugin cache (ui-ux-pro-max 2.11.0) |
+| `.claude/skills/ui-ux-pro-max/` (repo) | Not found |
+| `.cursor/skills/ui-ux-pro-max/` (repo) | Not found |
+| `.agents/skills/ui-ux-pro-max/` (repo) | Not found |
+| `.windsurf/skills/ui-ux-pro-max/` (repo) | Not found |
+| `~/.claude/skills/ui-ux-pro-max/` and other locations directly under home | Not found |
+| **Local plugin cache** | **Found and used**: local plugin cache (ui-ux-pro-max 2.11.0) |
 
-- 使用バージョン: **2.11.0**(ローカルにダウンロード済み。ネットからの再インストールはしていない)
-- 読了した SKILL.md: `<plugin>/.claude/skills/ui-ux-pro-max/SKILL.md`(Workflow: Step1 要件分析 → Step2 `--design-system` → Step3 `--domain` 補完 → Step4 `--stack` ガイドライン)
-- 実行スクリプト: `<plugin>/src/ui-ux-pro-max/scripts/search.py`(SKILL.md が参照する scripts/search.py と同一実装。フルパス指定で実行)
+- Version used: **2.11.0** (already downloaded locally; not reinstalled from the network)
+- SKILL.md read in full: `<plugin>/.claude/skills/ui-ux-pro-max/SKILL.md` (Workflow: Step1 requirements analysis → Step2 `--design-system` → Step3 `--domain` supplements → Step4 `--stack` guidelines)
+- Script executed: `<plugin>/src/ui-ux-pro-max/scripts/search.py` (the same implementation as scripts/search.py referenced by SKILL.md; executed using its full path)
 
-## 2. 実行コマンドと結果(spec §5 指定の 3 検索)
+## 2. Commands and results (the 3 searches specified in spec §5)
 
 1. `search.py "offline encryption privacy security mobile pwa" --design-system --persist -p "Offline Cipher"`
-   → パターン: Trust & Authority / スタイル: **Exaggerated Minimalism**(Light/Dark Full 対応, WCAG AA)/ パレット: 紺 `#1E3A5F`+緑 `#22C55E`+ダーク地 `#0F172A`("Shield dark + connected green")/ タイポ: JetBrains Mono(Google Fonts)/ Avoid: Playful, Poor security UX, AI purple-pink gradients。
-   **生成物(原本)**: `design-system/offline-cipher/MASTER.md`(スキルの persist 出力をそのまま保存)
+   → Pattern: Trust & Authority / Style: **Exaggerated Minimalism** (Light/Dark Full support, WCAG AA) / Palette: navy `#1E3A5F` + green `#22C55E` + dark background `#0F172A` ("Shield dark + connected green") / Typography: JetBrains Mono (Google Fonts) / Avoid: Playful, Poor security UX, AI purple-pink gradients.
+   **Generated artifact (original)**: `design-system/offline-cipher/MASTER.md` (the skill's persist output saved unchanged)
 2. `search.py "mobile bottom navigation qr code form accessibility" --stack react`
-   → semantic HTML(button/nav)、label `htmlFor` 必須(placeholder をラベルにしない)、props destructure。
+   → Semantic HTML (button/nav), mandatory label `htmlFor` (do not use a placeholder as a label), destructured props.
 3. `search.py "security key management warning destructive action" --domain ux`
-   → 破壊的操作は確認ダイアログ必須(直接削除禁止)、z-index はスケール運用(z-10/20/30/50、任意値禁止)。
+   → Destructive actions require a confirmation dialog (no direct deletion); use a z-index scale (z-10/20/30/50, no arbitrary values).
 
-出力全文は検索 1 が上記原本、検索 2/3 は結果全件を確定版へ反映済み。
+The full output of search 1 is in the original artifact above; all results from searches 2/3 were incorporated into the finalized version.
 
-## 3. 確定版への採用判断
+## 3. Adoption decisions for the finalized version
 
-確定版 `design-system/MASTER.md` は原本を次の方針で適合(理由は MASTER.md §0 の表にも記載):
+The finalized `design-system/MASTER.md` adapted the original as follows (the reasons are also recorded in the table in MASTER.md §0):
 
-- **採用**: パレット(紺/緑/ダーク)、Exaggerated Minimalism の高コントラスト・余白・装飾排除、Avoid リスト、Pre-Delivery Checklist、確認ダイアログ必須、z-index スケール、semantic HTML/`htmlFor`。
-- **変更**: JetBrains Mono(Google Fonts)→ **システムフォントスタック**(spec §17/18 の外部フォント・CDN 禁止と日本語グリフ対応のため。terminal/precision の気分はデータ表示のモノスペースで維持)。ダーク単一 → ライト/ダーク両トークン化(spec §6)。マーケティング型ページ構成 → ツール型 1 カラム(本アプリは utility PWA)。
-- **追加**: QR 面は常に白背景(spec §6)、機密度バッジ 3 段階、確認強度 3 段階、safe-area・44px タッチ領域・reduced-motion 規則(spec §6)。
+- **Adopted**: the palette (navy/green/dark); the high contrast, whitespace, and lack of decoration of Exaggerated Minimalism; the Avoid list; the Pre-Delivery Checklist; mandatory confirmation dialogs; the z-index scale; semantic HTML/`htmlFor`.
+- **Changed**: JetBrains Mono (Google Fonts) → **system font stack** (because spec §17/18 prohibits external fonts and CDNs, and to support Japanese glyphs; the terminal/precision feel is retained through monospace data displays). Dark-only → light/dark tokens (spec §6). Marketing page structure → a single-column tool layout (this app is a utility PWA).
+- **Added**: an always-white QR surface (spec §6), 3 sensitivity badge levels, 3 confirmation strength levels, and safe-area, 44px touch-target, and reduced-motion rules (spec §6).
 
-ページ別規則は `design-system/pages/{encrypt,keys,saved-qr,settings}.md`(spec §5 の指定 5 ファイル構成)。
+Page-specific rules are in `design-system/pages/{encrypt,keys,saved-qr,settings}.md` (the 5-file structure specified by spec §5).
 
-その後プロダクト名は Qrypt へ改名(2026-07-21)、さらに QR Crypt へ改名(2026-07-25)
+The product was later renamed to Qrypt (2026-07-21), then to QR Crypt (2026-07-25).
 
 ## 4. License
 
@@ -54,4 +54,4 @@ For publication, `design-system/offline-cipher/` (the raw persisted generator
 output duplicated by the adapted `MASTER.md`) and
 `design-system/pages/saved-qr.md` (the spec of the since-removed saved-QR
 page) were deleted from the tree. They remain available in git history.
-References to those paths in the Japanese sections above are historical.
+References to those paths in the translated sections above are historical.

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -2,7 +2,7 @@
 
 > **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
 
-This directory preserves Japanese design snapshots: RSA-era exports and later amendments to `MASTER.md` and some pages. The original exports were generated with the ui-ux-pro-max plugin v2.11.0 (MIT, Copyright (c) 2024 Next Level Builder). [PROVENANCE.md](PROVENANCE.md) records their origin and attribution.
+This directory preserves English translations of Japanese design snapshots: RSA-era exports and later amendments to `MASTER.md` and some pages. The original exports were generated with the ui-ux-pro-max plugin v2.11.0 (MIT, Copyright (c) 2024 Next Level Builder). [PROVENANCE.md](PROVENANCE.md) records their origin and attribution.
 
 These files are kept for historical reference and provenance only. They are not maintained, and their mixed snapshots do not describe a single version of the app.
 

--- a/design-system/pages/decrypt.md
+++ b/design-system/pages/decrypt.md
@@ -1,32 +1,32 @@
-# /decrypt — 復号ページ
+# /decrypt — Decryption page
 
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](../README.md) を参照してください。現行実装は [ソース](../../src/)・[テスト](../../tests/)、契約は [QR プロトコル仕様](../../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](../README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../../src/) and [Tests](../../tests/); for its contracts, see the [QR protocol specification](../../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../../docs/spec/boot-and-reset-v2.md).
 
-以下は当時の MASTER.md を前提としたページ別設計記録です。暗号化は別ルート `/encrypt`(`encrypt.md`)。
+This is a page-specific design record based on MASTER.md as it stood at the time. Encryption uses the separate `/encrypt` route (`encrypt.md`).
 
-## 構成
+## Structure
 
-- 入力: 「暗号文QRを読み取る」ボタン(`QrScannerModal`、対象=暗号文、単発とマルチフレームの両方)+ ペイロード貼り付け Textarea
-- 貼り付け: 種別確認行(方式・受信鍵ID)を表示して**自動復号しない**。「復号する」ボタンで実行
-- 読み取り: スキャナを閉じた時点で読めたペイロードをそのまま復号する。カメラを向ける操作自体が明示的な指示なので、確認ステップを挟まない
-- 復号鍵はペイロードの鍵IDから解決する。選択 UI は無い。対応する鍵が無ければ `KEY_NOT_FOUND` を表示してボタンを無効化する
-- マルチフレーム完了時は組み立て済みバイトを取り出したうえで `MultipartScanSession` を `discard()` し、アセンブラ側の複製を残さない
-- 署名鍵はストレージからの正確な index 解決(`findBundleBySigningKeyId`)。一覧キャッシュや「最新取り込み優先」は使わない。失効行は未知扱い
-- 復号結果モーダルの契約:
-  - `first-seen`: 平文をモーダルで表示(選択可能テキスト)。**メモリーのみ・保存しない**
-  - `already-received`: ラベル付き破壊的 replay アラートを出し、明示的な「それでも表示する」操作まで平文を出さない
-  - `MESSAGE_ID_REUSED`: エラー文言のみ。結果モーダルは**開かない**
-  - 署名有効かつ `fingerprint-confirmed`: 署名行に成功色、本人確認行も成功
-  - 署名有効だが未確認: 署名行は中立色。平文の上に破壊的 identity-unconfirmed アラート(タイトルと本文は `decrypt.result.identityUnconfirmed.*`、続けて identityCheck 文言)
-  - PQ 成功時は送信端末の申告時刻行(`decrypt.result.senderCreatedAt`)を出す。鮮度として扱わない
-  - セキュリティ Alert はタイトルに id を付け `aria-labelledby` で結ぶ。複数アラートを名前で区別できること
-- 署名鍵が未知の場合はモーダルを開かず、`SIGNING_KEY_NOT_FOUND` のアラートと `/keys` への導線だけを出す(部分平文表示禁止)
+- Input: "Scan ciphertext QR" button (`QrScannerModal`, targeting ciphertext, both single and multiframe) + a Textarea for pasting a payload
+- Paste: show a type confirmation row (method and recipient key ID) and **do not decrypt automatically**. Execute with the "Decrypt" button
+- Scan: when the scanner closes, decrypt the payload it has read directly. Pointing the camera is itself an explicit instruction, so no confirmation step is inserted
+- Resolve the decryption key from the payload's key ID. There is no selection UI. If no corresponding key exists, show `KEY_NOT_FOUND` and disable the button
+- On multiframe completion, extract the assembled bytes, then call `discard()` on `MultipartScanSession` so no copy remains in the assembler
+- Resolve the signing key through an exact storage index lookup (`findBundleBySigningKeyId`). Do not use a list cache or "most recently imported wins." Treat revoked rows as unknown
+- Decryption result modal contract:
+  - `first-seen`: show plaintext in the modal (selectable text). **Memory only; do not save**
+  - `already-received`: show a labelled destructive replay alert and withhold plaintext until an explicit "Show anyway" action
+  - `MESSAGE_ID_REUSED`: error text only. **Do not open** the result modal
+  - Valid signature and `fingerprint-confirmed`: use the success color for the signature row and show identity verification as successful too
+  - Valid signature but unconfirmed identity: use a neutral color for the signature row. Above the plaintext, show a destructive identity-unconfirmed alert (title and body from `decrypt.result.identityUnconfirmed.*`, followed by the identityCheck text)
+  - On PQ success, show the time reported by the sending device (`decrypt.result.senderCreatedAt`). Do not treat it as evidence of freshness
+  - Give each security Alert title an id and associate it via `aria-labelledby`. Multiple alerts must be distinguishable by name
+- If the signing key is unknown, do not open the modal; show only a `SIGNING_KEY_NOT_FOUND` alert and a link to `/keys` (no partial plaintext display)
 
-## 平文の扱い
+## Plaintext handling
 
-- 復号結果は自動保存・復元しない(state のみ)
-- セッションレシート(`src/features/receipt-cache.ts`)は平文とは別のセッションメモリー構造。認証済みメッセージごとの bounded Map で、document 寿命で消え、reload では生き残らない。IndexedDB / localStorage / CacheStorage には書かない
-- 既定 ON の「バックグラウンド移行後に自動消去」が有効な場合、visibilitychange hidden から env 固定の約5分経過で暗号文入力・復号結果を消去し、スキャンセッションを破棄する
-- `oc:clear-transient` イベント(設定ページ「すべての平文を消去」)で即時消去。レシートも wipe / transient-clear 経路で `clearReceipts()` される
-- ページのアンマウント時にも `MultipartScanSession` を破棄する。ルートが分かれたことでアンマウントが日常的に起きる
+- Do not automatically save or restore decryption results (state only)
+- Session receipts (`src/features/receipt-cache.ts`) are a session-memory structure separate from plaintext. A bounded Map tracks authenticated messages, disappears at the end of the document's lifetime, and does not survive reload. Do not write it to IndexedDB / localStorage / CacheStorage
+- When "Automatically clear after moving to the background" is enabled (ON by default), clear the ciphertext input and decryption result and discard the scan session approximately 5 minutes after visibilitychange hidden; the delay is fixed by env
+- Clear immediately on the `oc:clear-transient` event ("Clear all plaintext" on the settings page). Receipts are also cleared with `clearReceipts()` through the wipe / transient-clear paths
+- Also discard `MultipartScanSession` when the page unmounts. With separate routes, unmounting is routine

--- a/design-system/pages/encrypt.md
+++ b/design-system/pages/encrypt.md
@@ -1,28 +1,28 @@
-# /encrypt — 暗号化ページ(既定ページ)
+# /encrypt — Encryption page (default page)
 
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](../README.md) を参照してください。現行実装は [ソース](../../src/)・[テスト](../../tests/)、契約は [QR プロトコル仕様](../../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](../README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../../src/) and [Tests](../../tests/); for its contracts, see the [QR protocol specification](../../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../../docs/spec/boot-and-reset-v2.md).
 
-以下は当時の MASTER.md を前提としたページ別設計記録です。復号は別ルート `/decrypt`(`decrypt.md`)。
+This is a page-specific design record based on MASTER.md as it stood at the time. Decryption uses the separate `/decrypt` route (`decrypt.md`).
 
-## 構成(上から、spec §7.1 の順序厳守)
+## Structure (top to bottom, strictly following spec §7.1)
 
-1. アプリ名(h1、ヘッダー内)
-2. ネットワーク状態バッジ(ヘッダー右)
-3. 暗号化方式選択 — `Select`。表示名は spec §7.3 どおり:「共通鍵 — AES-256-GCM」「公開鍵 — RSA-OAEP-3072 + AES-256-GCM」。`enableRsa=false` なら B を出さない
-4. 使用鍵選択 — `Select`。方式で絞る(A=共通鍵 / B=公開鍵・鍵ペア公開側)。候補 0 件なら「鍵ページで作成してください」の空状態リンク。鍵名+指紋先頭 1 グループを併記
-5. 平文入力 — `Textarea`(min-h 120px、複数行)。下に「文字数 / UTF-8 バイト数(mono, aria-live=polite)」と上限 4096B。超過時: バイト数を destructive 色+アイコン+説明、暗号化ボタン無効
-6. バイト数・予想QRサイズ — 「予想ペイロード: 約 N 文字 / EC=Q 上限 1663」形式。収まらない見込みは警告アイコン+文言
-7. 暗号化ボタン — primary、全幅、44px。無効条件: 鍵未選択・平文空・バイト超過・処理中(spinner+「暗号化中…」)
-8. 暗号結果 — 成功時のみ。ペイロード文字列(mono、break-all、max-h 96px スクロール、コピー)
-9. 暗号文QR — QR 表示パネル(白固定)。生成失敗時は理由(例: サイズ超過)を `role="alert"`
-10. QR名入力 — `Input`。自動提案 `暗号文-YYYYMMDD-HHmmss`。1〜80 文字検証
-11. 操作列 — 保存(アプリ内)/ PNG / SVG / コピー。保存成功はトースト+保存済みへのリンク。重複(同一 payloadSha256)は確認ダイアログ「同じ内容のQRが保存済みです」
-12. 詳細情報 — `Collapsible`「詳細」: アルゴリズム・鍵ID・作成日時・IV(hex)・暗号文サイズ・AAD 内容
+1. App name (h1, in the header)
+2. Network status badge (right side of the header)
+3. Encryption method selector — `Select`. Display names follow spec §7.3: "Symmetric key — AES-256-GCM" and "Public key — RSA-OAEP-3072 + AES-256-GCM." Hide B when `enableRsa=false`
+4. Key selector — `Select`. Filter by method (A = symmetric key / B = public key or the public part of a key pair). If there are 0 candidates, show an empty-state link: "Create a key on the keys page." Show the key name + the first group of its fingerprint
+5. Plaintext input — `Textarea` (min-h 120px, multiline). Below it, show "Character count / UTF-8 byte count (mono, aria-live=polite)" and the 4096B limit. When exceeded: use the destructive color + icon + explanation for the byte count, and disable the encryption button
+6. Byte count and estimated QR size — format: "Estimated payload: about N characters / EC=Q limit 1663." If it is unlikely to fit, show a warning icon + text
+7. Encryption button — primary, full width, 44px. Disabled when: no key selected, plaintext empty, byte limit exceeded, or processing (spinner + "Encrypting…")
+8. Encryption result — only on success. Payload string (mono, break-all, max-h 96px with scrolling, copy)
+9. Ciphertext QR — QR display panel (fixed white background). On generation failure, show the reason (e.g. size limit exceeded) with `role="alert"`
+10. QR name input — `Input`. Automatic suggestion: `Ciphertext-YYYYMMDD-HHmmss` (English translation of the historical Japanese name template). Validate 1–80 characters
+11. Action row — Save (in-app) / PNG / SVG / Copy. On successful save, show a toast + a link to saved items. For a duplicate (same payloadSha256), show a confirmation dialog: "A QR with the same content is already saved"
+12. Details — `Collapsible` labelled "Details": algorithm, key ID, creation date/time, IV (hex), ciphertext size, and AAD contents
 
-## 平文の扱い(spec §7.2)
+## Plaintext handling (spec §7.2)
 
-- 自動保存・復元をしない(state のみ)。「平文を消去」ボタン常設(入力があるときのみ活性)
-- 暗号化成功後: 既定 ON の設定「暗号化後に平文を自動消去」が ON なら消去+トースト、OFF なら残す
-- 既定 ON の「バックグラウンド移行後に自動消去」が有効な場合、visibilitychange hidden から env 固定の約5分経過で平文・復号結果・結果ペイロードを消去(復帰時に「自動消去しました」表示)
-- `oc:clear-transient` イベント(設定ページ「すべての平文を消去」)で即時消去
+- Do not automatically save or restore plaintext (state only). Always show the "Clear plaintext" button (enabled only when input exists)
+- After successful encryption: if "Automatically clear plaintext after encryption" (ON by default) is ON, clear it + show a toast; if OFF, retain it
+- When "Automatically clear after moving to the background" is enabled (ON by default), clear plaintext, decryption results, and the result payload approximately 5 minutes after visibilitychange hidden; the delay is fixed by env (show "Automatically cleared" on return)
+- Clear immediately on the `oc:clear-transient` event ("Clear all plaintext" on the settings page)

--- a/design-system/pages/keys.md
+++ b/design-system/pages/keys.md
@@ -1,46 +1,46 @@
-# /keys — 鍵一覧ページ
+# /keys — Key list page
 
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](../README.md) を参照してください。現行実装は [ソース](../../src/)・[テスト](../../tests/)、契約は [QR プロトコル仕様](../../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](../README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../../src/) and [Tests](../../tests/); for its contracts, see the [QR protocol specification](../../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../../docs/spec/boot-and-reset-v2.md).
 
-以下は当時の MASTER.md を前提としたページ別設計記録です。旧 `/saved` 相当の鍵一覧。ページ見出し・サブタイトルは出さない。作成・読込 UI はページ本体ではなく `KeyAddDialog` モーダル(`src/components/key-add-dialog.tsx`)に置く。
+This is a page-specific design record based on MASTER.md as it stood at the time. The key list corresponds to the former `/saved` page. Do not show a page heading or subtitle. Place creation and import UI in the `KeyAddDialog` modal (`src/components/key-add-dialog.tsx`), rather than in the page body.
 
-## 一覧クロム
+## List controls
 
-- `Tabs`: 自分の鍵 / 相手の鍵
-- タブ直下に操作 2 つを 2 等分で並べる。`TabsList`(`role="tablist"`)の外に置き、視覚的にも別の要素として独立させる(枠で囲って一体に見せない)。いずれも `Button variant="outline"`、44px、アイコン + ラベル:
-  - Plus — 鍵を作成 → `KeyAddDialog` を create モードで開く
-  - ScanLine — 鍵QRを読み取る → 同モーダルを import モードで開く
-- 作成直後は同一モーダル内で鍵詳細ビューへ切り替える(別ダイアログへ遷移しない)
+- `Tabs`: My keys / Others' keys
+- Place 2 equally sized actions directly below the tabs. Keep them outside `TabsList` (`role="tablist"`) and visually separate (do not enclose them in a border that makes them look like one element). Both use `Button variant="outline"`, 44px, icon + label:
+  - Plus — Create key → open `KeyAddDialog` in create mode
+  - ScanLine — Scan key QR → open the same modal in import mode
+- Immediately after creation, switch to the key detail view inside the same modal (do not transition to a separate dialog)
 
-## 作成モード(`KeyAddDialog` create)
+## Create mode (`KeyAddDialog` create)
 
-- 「共通鍵を生成」/「鍵ペアを生成」などの作成フォーム(鍵名 Input + 生成ボタン primary)。生成後は詳細ビューへ切替+トースト
-- **共通鍵 QR**: 「QR を表示」で即 QrDisplay(白面、全画面可)を表示する。「暗号化と復号に使える秘密鍵を含む」という説明だけを添え、警告 Alert、確認チェックボックス、表示・コピー・ダウンロードのゲートは置かない。
-- QR 画面の操作: QR の下にコピー、ダウンロードの順で2ボタンを1行に並べる。アプリ内保存・命名保存・SVG 操作(Saved-QR / `qrArtifacts`)は無い。単一画像として操作列は置かず、左寄せのアイコンのみ全画面ボタンを表示し、全画面面は右寄せの閉じるボタンだけを表示する。
-- 公開鍵ペア: RSA-3072 生成は数秒かかる → ボタン内 spinner+「生成中…(数秒かかります)」、二重実行防止。公開鍵 QR は警告不要で、説明は共通鍵 QR と同じ構造の「暗号化と署名検証に使う公開鍵を含む」とする。秘密鍵は QR 表示・エクスポート UI を出さない(`enablePrivateKeyExport=false` 固定)
-- 重複: 生成/取込時に指紋一致があれば DUPLICATE_KEY 文言+既存鍵名を表示し保存しない。PQ 公開バンドル取込は KEM/署名アルゴリズムと両方の公開鍵バイトが一致する再取込を `DUPLICATE_KEY`、それ以外の鍵ID衝突(部分衝突・失効行との衝突を含む)を `KEY_ID_CONFLICT` で拒否する。ただし、いずれかの一致行が失効済みなら、同じ鍵素材でも、一覧から隠れた利用停止済みバンドルによる予約として常に `KEY_ID_CONFLICT` にする
+- Creation forms such as "Generate symmetric key" / "Generate key pair" (key name Input + primary generation button). After generation, switch to the detail view + show a toast
+- **Symmetric key QR**: "Show QR" immediately displays QrDisplay (white surface, fullscreen available). Include only the explanation "Contains a secret key that can be used for encryption and decryption"; do not add a warning Alert, confirmation checkbox, or gates for display, copy, or download.
+- QR screen actions: below the QR, place 2 buttons in one row, Copy then Download. There are no in-app save, named-save, or SVG actions (Saved-QR / `qrArtifacts`). For a single image, omit the action row and show a left-aligned, icon-only fullscreen button; in fullscreen, show only a right-aligned close button.
+- Public-key pair: RSA-3072 generation takes several seconds → spinner inside the button + "Generating… (this takes a few seconds)"; prevent duplicate execution. Public key QRs need no warning; use an explanation with the same structure as for symmetric key QRs: "Contains public key material used for encryption and signature verification." Do not provide QR display or export UI for private keys (`enablePrivateKeyExport=false` fixed)
+- Duplicates: if a matching fingerprint exists during generation/import, show DUPLICATE_KEY text + the existing key name, and do not save. For PQ public bundle imports, reject a reimport with matching KEM/signature algorithms and both public-key byte sequences as `DUPLICATE_KEY`; reject other key-ID collisions (including partial collisions and collisions with revoked rows) as `KEY_ID_CONFLICT`. However, if either matching row is revoked, always use `KEY_ID_CONFLICT` even for identical key material: the disabled bundle hidden from the list reserves those IDs
 
-## 読込モード(`KeyAddDialog` import)
+## Import mode (`KeyAddDialog` import)
 
-1. 読取対象を先に選択(RadioGroup 縦 44px): 「共通鍵を読み取る」/「公開鍵を読み取る」(spec §16。暗号文の読取は `/decrypt`)
-2. 「カメラを起動」ボタン → QrScannerDialog(カメラ権限はこの時点で要求)
-3. 読取成功 → 確認カード: 種別 / 方式 / 指紋(4×4 mono、照合を促す文言「相手の画面の指紋と一致することを確認してください」+**完全 SHA-256 hex も併記・コピー可**。短縮表示は簡易照合である旨を添える)/ 作成日時 + 鍵名入力(提案 `共通鍵-取込` 等)
-   - 選択した対象種別とプレフィックス不一致 → 拒否文言(例: 「これは公開鍵のQRです。読取対象を切り替えてください」)
-   - 共通鍵の保存は追加確認(チェックボックス「この鍵の共有経路を信頼しています」)
-   - 指紋重複 → DUPLICATE_KEY(既存鍵名提示、保存不可)
-   - PQ バンドル: KEM/署名アルゴリズムと両方の公開鍵バイトが一致する再取込 → DUPLICATE_KEY; いずれかの鍵IDが既存(失効行含む)と衝突 → KEY_ID_CONFLICT(保存不可)。一致行が失効済みなら、同じ鍵素材でも KEY_ID_CONFLICT
-4. 失敗: CAMERA_PERMISSION_DENIED / CAMERA_NOT_AVAILABLE を文言+対処(設定アプリで許可 等)で表示
+1. Select the scan target first (vertical RadioGroup, 44px): "Scan symmetric key" / "Scan public key" (spec §16; ciphertext scanning is on `/decrypt`)
+2. "Start camera" button → QrScannerDialog (request camera permission at this point)
+3. Successful scan → confirmation card: type / method / fingerprint (4×4 mono, with a comparison prompt, "Confirm that the fingerprint matches the one on the other person's screen," + **the full SHA-256 hex alongside it, copyable**. Explain that the shortened display is a quick check) / creation date/time + key name input (suggestions such as `Symmetric-key-import`, an English translation of the historical Japanese name)
+   - Prefix does not match the selected target type → rejection text (e.g. "This is a public key QR. Change the scan target")
+   - Saving a symmetric key requires extra confirmation (checkbox: "I trust the channel used to share this key")
+   - Duplicate fingerprint → DUPLICATE_KEY (show the existing key name; saving is unavailable)
+   - PQ bundle: reimport with matching KEM/signature algorithms and both public-key byte sequences → DUPLICATE_KEY; either key ID collides with an existing row (including revoked rows) → KEY_ID_CONFLICT (saving is unavailable). If a matching row is revoked, use KEY_ID_CONFLICT even for identical key material
+4. Failure: show CAMERA_PERMISSION_DENIED / CAMERA_NOT_AVAILABLE with explanatory text + a remedy (e.g. grant permission in the settings app)
 
-## 一覧行操作
+## List row actions
 
-- 行操作(DropdownMenu / 詳細): QR を表示 / 名前を変更 / 失効(公開バンドル) / 削除
-- 失効(公開バンドル): 確認文言に、失効すると行が非表示になり、このインストールでは署名鍵IDとKEM鍵IDの両方が永久に予約されること、元に戻せず、その後この画面から削除もできないこと、予約を解除できるのはローカルデータの全消去だけであることを明記する。両IDを解放する必要がある場合は、失効前に削除を選ぶ
-- 削除: AlertDialog(通常確認)+「この鍵で復号できなくなります」説明。秘密鍵ありの鍵ペアは**強確認**
-- 機密度バッジ「最高機密」は共通鍵で常時表示
+- Row actions (DropdownMenu / details): Show QR / Rename / Revoke (public bundle) / Delete
+- Revoke (public bundle): the confirmation text must state that revocation hides the row and permanently reserves both the signing key ID and KEM key ID in this installation; it cannot be undone, and the row cannot subsequently be deleted from this screen. Only clearing all local data releases the reservation. If both IDs need to be released, choose Delete before revoking
+- Delete: AlertDialog (normal confirmation) + explanation, "You will no longer be able to decrypt with this key." Key pairs containing a private key require **strong confirmation**
+- Always show the "Highly sensitive" sensitivity badge for symmetric keys
 
-## QrScannerDialog 共通規則
+## Shared QrScannerDialog rules
 
-- 開いたときのみ getUserMedia。閉じる(成功・キャンセル・エラーいずれも)でストリーム必ず停止
-- 読取成功時は即ロック(多重発火防止)、ビープ等の音は鳴らさない、読取画像を保存しない
-- 枠ガイド+「QRコードを枠内に合わせてください」、`aria-live` で状態通知
+- Call getUserMedia only when opened. Always stop the stream when closed (whether success, cancellation, or error)
+- Lock immediately on a successful scan (prevent repeated firing); do not play beeps or other sounds, and do not save scanned images
+- Frame guide + "Align the QR code within the frame"; announce status with `aria-live`

--- a/design-system/pages/online-gate.md
+++ b/design-system/pages/online-gate.md
@@ -1,50 +1,50 @@
-# OnlineGate — オンライン導入・暗号文QRリレー
+# OnlineGate — Online setup and ciphertext QR relay
 
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](../README.md) を参照してください。現行実装は [ソース](../../src/)・[テスト](../../tests/)、契約は [QR プロトコル仕様](../../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](../README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../../src/) and [Tests](../../tests/); for its contracts, see the [QR protocol specification](../../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../../docs/spec/boot-and-reset-v2.md).
 
-以下は後の改訂と廃止済み OCM1 の規則が混在する、当時の設計記録です。
+This historical design record mixes later revisions with rules for the retired OCM1 format.
 
-機能検出ゲートの次、通常ルーターの前に配置する全画面ゲート。オンライン中は `/encrypt`・`/decrypt`・`/keys`・`/settings` を一切表示せず、PWA の導入情報と、鍵・PQ 身元・Vault 鍵の各ストアが読めた上で 1 行も無いと確認できた場合（読み取り失敗は不許可側に倒す fail-closed）だけ、正規 OCM1 メッセージ 1 件または OCF2 フレーム一式を扱う暗号文 QR リレーを表示する。オンラインシェル自体の固定 localStorage 書き込み（`oc-theme` / `oc-lang` / ack マーカー / 最後に開いたタブ `oc-online-tab`）は従来どおり行われるため「保存領域が空」ではない。鍵を保持する端末をオンラインにしない運用は変わらない。
+A fullscreen gate placed after feature detection and before the normal router. While online, never show `/encrypt`, `/decrypt`, `/keys`, or `/settings`; show PWA setup information and, only when the key, PQ identity, and Vault key stores have all been read successfully and confirmed to contain 0 rows (fail closed on read failure), a ciphertext QR relay handling 1 canonical OCM1 message or a complete set of OCF2 frames. The online shell still performs its fixed localStorage writes (`oc-theme` / `oc-lang` / ack markers / last-opened tab `oc-online-tab`), so this does not mean "storage is empty." The operational rule that a device holding keys must not go online remains unchanged.
 
-## 表示内容
+## Display content
 
-- 言語選択、アプリアイコン、アプリ名、ネットワーク状態バッジ（オンライン）はトップ / リレーの両ページに共通して表示する。
-- トップページ:
-  - PWA インストール状態（インストール済み / 未インストール）
-  - `beforeinstallprompt` を捕捉できた場合の「PWAをインストール」ボタン
-  - iOS Safari では共有メニューの「ホーム画面に追加」手順
-  - Service Worker の offlineReady（準備完了 / 準備中）
-  - 「オフライン（機内モード）に切り替えると暗号化・復号・鍵管理・設定が利用できます」という主案内（オフライン表示は安全性の証明として表現しない）
-- リレーページ:
-  - boot の破壊判断完了後に限る「暗号文QRリレー」カード。正規 OCM1 メッセージ 1 件または、信頼できない外側ヘッダが `pq-message` と表明する正規 OCF2 フレーム一式を受け入れる
-  - 「QR → テキスト」（英語ラベルは `QR → Text`）: ボタンでダイアログを開き、さらに明示操作した時だけカメラを取得する。OCM1 は 1 回のスキャンで取り込みを完了し、OCF2 は一式を収集する
-  - 「テキスト → QR」: OCM1 文字列 1 件または改行区切りの OCF2 フレーム一式を貼り付ける。OCF2 は既存の animated QR で再生し、OCM1 は単一 QR として表示する
-  - 「QR → QR」: 「QR → テキスト」と同じカメラ取得経路を使い、受け入れた最初のフレームが `frameCount > 1` を宣言した場合は取り込みを破棄してカメラを止め、「QR → テキスト」を使うよう案内する。1 フレームで完結する場合だけ、その正規文字列を `renderQrDataUrl` で QR 画像として描き直し、「QR画像をコピー」を提供する。ダウンロード操作は追加しない（`relay.playback.noDownloadControls` は真のまま）
-  - 3 つのボタンは `sm:grid-cols-3` の 1 行に矢印ラベルだけを並べ、その直下に「QR → QR」の利用条件（メッセージアプリが画像貼り付けに対応し、かつ 1 枚の QR に収まること）を示すヒント文を両言語で置く
-  - ダイアログ自身に上端・下端の safe-area padding を持たせる
-  - 44 px 操作、`focus-visible:ring-2`、lucide のアイコン＋テキストを使う
-- relay eligible の時だけ、共通下部シェルにアイコンのみの「トップ」「リレー」2 項目を表示する。選択したリレータブの eligibility が一時的に pending になった間もナビを消さないため、表示条件 `navVisible` は `relayEligible || tab === "relay"` とする。固定ナビ表示中は本文に `pb-content-safe` を付ける。
-- 下部操作は offline ナビと同じ `<nav>` + 各 `<button aria-current="page">` のページナビとして扱い、`role="tablist"` は使わない。
-- ナビを押した時だけ選択タブを localStorage `oc-online-tab`（`top` / `relay` の 2 値のみ）へ保存し、次回起動はその値で開く。未設定・未知の値は `top`。オンライン専用端末が毎回リレーを選び直さずに済むことが目的で、一度も押していない端末は書き込まない。`oc-*` 全削除で消えるため wipe / 全初期化後はトップに戻る。
-- 保存値 `relay` の復元は relay eligible が確定してからに限る。ineligible / 判定待ちの間は復元せず `tab` は `top` のままなので、ナビも書き込み経路も現れない（`navVisible` の既存規則を跨いだ復元で緩めない）。
+- Show language selection, the app icon, app name, and network status badge (Online) on both the Top and Relay pages.
+- Top page:
+  - PWA installation status (Installed / Not installed)
+  - "Install PWA" button when `beforeinstallprompt` has been captured
+  - Instructions for "Add to Home Screen" in the share menu on iOS Safari
+  - Service Worker offlineReady (Ready / Preparing)
+  - Main guidance: "Switch to offline mode (airplane mode) to use encryption, decryption, key management, and settings" (do not describe an offline indicator as proof of safety)
+- Relay page:
+  - "Ciphertext QR relay" card, available only after boot has completed its wipe decision. Accept 1 canonical OCM1 message or a complete set of canonical OCF2 frames whose untrusted outer headers declare `pq-message`
+  - "QR → Text" (the English label was `QR → Text`): the button opens a dialog; acquire the camera only after a further explicit action. OCM1 capture completes in 1 scan; OCF2 collects the complete set
+  - "Text → QR": paste 1 OCM1 string or a complete set of newline-delimited OCF2 frames. Play OCF2 with the existing animated QR display; show OCM1 as a single QR
+  - "QR → QR": use the same camera acquisition path as "QR → Text." If the first accepted frame declares `frameCount > 1`, discard the capture, stop the camera, and direct the user to "QR → Text." Only when complete in 1 frame, redraw that canonical string as a QR image with `renderQrDataUrl` and offer "Copy QR image." Do not add a download action (`relay.playback.noDownloadControls` remains true)
+  - Arrange the 3 buttons in one `sm:grid-cols-3` row with only the arrow labels. Immediately below, provide a hint in both languages explaining the requirements for "QR → QR" (the messaging app must support pasting images, and the message must fit in 1 QR)
+  - Give the dialog itself top and bottom safe-area padding
+  - Use 44 px controls, `focus-visible:ring-2`, and lucide icons + text
+- Only when relay eligible, show 2 icon-only items, "Top" and "Relay," in the shared bottom shell. To keep navigation visible while the selected Relay tab's eligibility is temporarily pending, use `navVisible` = `relayEligible || tab === "relay"`. Add `pb-content-safe` to the body while fixed navigation is visible.
+- Treat the bottom controls as page navigation using `<nav>` + individual `<button aria-current="page">` elements, like the offline navigation; do not use `role="tablist"`.
+- Save the selected tab to localStorage `oc-online-tab` (only 2 values: `top` / `relay`) only when navigation is pressed, and open that tab on the next launch. Missing or unknown values mean `top`. This avoids making an online-only device select Relay on every launch; do not write on a device where navigation has never been pressed. Deleting all `oc-*` entries removes it, so wipe / full reset returns to Top.
+- Restore a saved `relay` value only after relay eligibility is confirmed. While ineligible / pending, do not restore it: `tab` stays `top`, so neither navigation nor its write path appears (do not weaken the existing `navVisible` rule by restoring across that boundary).
 
-## 状態遷移と保護
+## State transitions and protections
 
-- relay は `network-confirmed/eligible` かつ表示状態も online の時だけ表示する。decision pending、`wiping`、`partial-failure`、maintenance token で鍵が残った場合、`wipeOnOnline:false` で鍵が残った場合、保存領域を読み切れない場合は表示しない。
-- 選択状態 `tab` は eligibility 変化でリセットしない。表示パネルだけを `activeTab = relayEligible ? tab : "top"` でトップへ fail-closed し、トップとリレーの wrapper は `hidden` 属性で切り替える。
-- `OnlineRelay` のコンポーネント instance はトップ / リレーのどちらを表示している間も常に mount し、eligibility が false の時も条件付き mount にしない。これにより `visibilitychange` / `pagehide` / `pageshow` の監視と session-end handler 登録を維持し、`openDialog` 内で eligibility refresh が同期的に pending を emit しても pending-open generation を失わず、判断完了後にダイアログを開ける。
-- `keys`・`pqIdentities`・Vault key metadata・preferences は boot の同一 readonly transaction で確認し、open/store/count/get/transaction のどの失敗も `indeterminate` として fail-closed に扱う。
-- online→offline: relay の命令的 `endSession` を同期実行してからゲートを閉じる。通常ページは既存の acknowledgement 条件を満たすまで表示しない。
-- offline→online: 通常ページを即時隠し、同時に TransientClear を発火して平文・復号結果・結果ペイロードを消去する。
-- relay を開く直前と visible への `visibilitychange` で空状態を再確認する。cross-tab の排他 lease は持たないため、確認直後に別タブが鍵を作る stale-policy race は残る。
-- camera startup の AbortController と取得済み `QrScanHandle.stop()` は別々に保持し、close、unmount、hidden、pagehide、BFCache pageshow、表示/eligibility 喪失、local/peer wipe、timeout、terminal error のすべてで両方を終了する。BFCache 復帰時に自動再取得しない。
-- Web Crypto または IndexedDB が不足する場合は、OnlineGate より先に `UNSUPPORTED_BROWSER` を表示する。
-- オフライン表示は運用上の機能許可条件であり、安全性の証明として表現しない。
+- Show the relay only when `network-confirmed/eligible` and the display state is also online. Do not show it while the decision is pending, during `wiping` or `partial-failure`, when keys remain because of a maintenance token or `wipeOnOnline:false`, or when storage cannot be read completely.
+- Do not reset the selected `tab` when eligibility changes. Fail closed by showing only the Top panel through `activeTab = relayEligible ? tab : "top"`; switch the Top and Relay wrappers with the `hidden` attribute.
+- Keep the `OnlineRelay` component instance mounted while either Top or Relay is displayed; do not conditionally unmount it when eligibility is false. This preserves `visibilitychange` / `pagehide` / `pageshow` monitoring and session-end handler registration. Even if an eligibility refresh inside `openDialog` synchronously emits pending, the pending-open generation survives so the dialog can open after the decision completes.
+- Check `keys`, `pqIdentities`, Vault key metadata, and preferences in the same readonly boot transaction; treat any open/store/count/get/transaction failure as `indeterminate` and fail closed.
+- online→offline: synchronously call the relay's imperative `endSession` before closing the gate. Do not show normal pages until the existing acknowledgement conditions are met.
+- offline→online: hide normal pages immediately and simultaneously fire TransientClear to clear plaintext, decryption results, and the result payload.
+- Recheck the empty state immediately before opening the relay and on `visibilitychange` to visible. There is no cross-tab exclusive lease, so a stale-policy race remains if another tab creates keys immediately after the check.
+- Keep the camera-startup AbortController and acquired `QrScanHandle.stop()` separately; terminate both on close, unmount, hidden, pagehide, BFCache pageshow, loss of visibility/eligibility, local/peer wipe, timeout, and terminal error. Do not automatically reacquire the camera on BFCache return.
+- If Web Crypto or IndexedDB is unavailable, show `UNSUPPORTED_BROWSER` before OnlineGate.
+- An offline indicator is an operational condition for enabling features; do not present it as proof of safety.
 
-## リレー境界の表現
+## Describing the relay boundary
 
-- 受け入れるのは「信頼できない外側ヘッダーが `pq-message` と表明する正規 OCF2 フレーム」または「エンベロープ全体の decode と canonical re-encode が入力と byte-for-byte で一致する正規 OCM1 メッセージ 1 件」。OCM1 の確認は構造的正規性だけを示す。リレーは OCF2 を再組立せず、全体 hash、AEAD、署名、送信者、真正性、安全性を検証せず、何も復号しない。トップレベルの鍵アーティファクトのプレフィックスと不許可の OCF2 外部タイプを拒否しても、受け入れた不透明なバイト列に鍵素材が含まれないことは保証できない。受信側オフライン端末を authority とし、鍵交換は対面を推奨運用として示す。
-- OCF2 フレーム文字列は検証後も verbatim で保持し、順序だけ index 昇順にして LF で結合する。再組立・再分割・density control は行わない。OCM1 は正規性確認後に単一 QR として再表示し、animation control は表示しない。
-- Copy は clipboard への意図的 export であり、アプリ外に残存・同期し得る警告を表示する。これはテキストの copy だけでなく「QR → QR」の PNG `ClipboardItem` 書き出しにも同じく当てはまり、そちらにも専用の警告文を表示する。QR は長押し保存、印刷、screenshot、画面録画を防げない。
-- enforceable な UI 制約は「アプリ提供のファイル download control がないこと」。frame-derived 値と OCM1-derived 値を app-managed IndexedDB/localStorage/CacheStorage/URL/history/log や relay-payload-bearing network request に意図的に書き込まない。shell 固有の固定 storage/network 動作は別に存在する。
+- Accept only "canonical OCF2 frames whose untrusted outer headers declare `pq-message`" or "1 canonical OCM1 message whose full-envelope decode and canonical re-encode match the input byte-for-byte." The OCM1 check establishes only structural canonicality. The relay does not reassemble OCF2 or verify the whole hash, AEAD, signatures, senders, authenticity, or safety. It decrypts nothing. Rejecting top-level key-artifact prefixes and disallowed OCF2 outer types cannot guarantee that accepted opaque bytes contain no key material. Treat the receiving offline endpoint as the authority, and recommend in-person key exchange as an operational practice.
+- Retain OCF2 frame strings verbatim even after validation; only sort them by ascending index and join them with LF. Do not reassemble, resplit, or provide density control. Redisplay OCM1 as a single QR after the canonicality check, without animation controls.
+- Copy is an intentional export to the clipboard; show a warning that the data may persist or sync outside the app. This applies both to text copy and to PNG `ClipboardItem` export in "QR → QR"; provide dedicated warning text for the latter too. QR displays cannot prevent long-press saving, printing, screenshots, or screen recording.
+- The enforceable UI constraint is "no app-provided file download controls." Do not intentionally write frame-derived or OCM1-derived values to app-managed IndexedDB/localStorage/CacheStorage/URL/history/log or relay-payload-bearing network requests. The shell has separate fixed storage/network behavior.

--- a/design-system/pages/settings.md
+++ b/design-system/pages/settings.md
@@ -1,51 +1,53 @@
-# /settings — 設定ページ
+# /settings — Settings page
 
-> **アーカイブ（現行実装の仕様ではありません）。** ここに記された RSA・OCM1・EC レベル選択を現行実装の要件として採用しないでください。
-> 来歴と保存範囲は [README](../README.md) を参照してください。現行実装は [ソース](../../src/)・[テスト](../../tests/)、契約は [QR プロトコル仕様](../../docs/spec/qr-protocol-v2.md)・[起動とリセットの仕様](../../docs/spec/boot-and-reset-v2.md) を参照してください。
+> **Archive — not current implementation specifications.** Do not use the retired RSA, OCM1, or EC-level selector controls described here as active implementation requirements.
+> See [README](../README.md) for provenance and the scope of preservation. For the current implementation, see [Source](../../src/) and [Tests](../../tests/); for its contracts, see the [QR protocol specification](../../docs/spec/qr-protocol-v2.md) and [Boot and reset specification](../../docs/spec/boot-and-reset-v2.md).
 
-以下は当時の MASTER.md を前提としたページ別設計記録です。セクションは Card 区切り、見出し h2。spec §28 の全項目を以下の 5 セクションに配置。
+This is a page-specific design record based on MASTER.md as it stood at the time. Separate sections with Cards and use h2 headings. The recorded layout places all items from spec §28 in the following 5 sections.
 
-## 1. 既定値
+## 1. Defaults
 
-- デフォルト暗号方式(Select: A256GCM / RSA ハイブリッド ※enableRsa 時のみ)
-- デフォルトQR誤り訂正レベル(Select: L/M/Q/H + 説明「高いほど読み取りに強く、入る量は減ります」)
+- Default encryption method (Select: A256GCM / RSA hybrid, the latter only when enableRsa is enabled)
+- Default QR error correction level (Select: L/M/Q/H + explanation, "Higher levels are more resilient when scanning, but hold less data")
 
-## 2. 平文の扱い
+## 2. Plaintext handling
 
-- 暗号化後に平文を自動消去(Switch、既定 ON)
-- バックグラウンド移行後に自動消去(Switch、既定 ON)。遅延は env `VITE_AUTO_CLEAR_SECONDS=300` の固定値で、説明に「約5分後」と表示する
-- 「すべての平文を消去」ボタン(secondary)→ `oc:clear-transient` 発火+トースト
+- Automatically clear plaintext after encryption (Switch, ON by default)
+- Automatically clear after moving to the background (Switch, ON by default). The delay is fixed by env `VITE_AUTO_CLEAR_SECONDS=300`; the explanation says "after approximately 5 minutes"
+- "Clear all plaintext" button (secondary) → fire `oc:clear-transient` + show a toast
 
-## 3. 表示
+## 3. Display
 
-- テーマ(Select: システム / ライト / ダーク)→ `localStorage['oc-theme']`
+- Theme (Select: System / Light / Dark) → `localStorage['oc-theme']`
 
-## 4. アプリ情報(PWA)
+## 4. App information (PWA)
 
-- PWA インストール状態(standalone 判定: インストール済み / ブラウザー表示中)
-- オフライン利用準備状態(SW offlineReady: 準備完了 / 準備中)— **安全性の主張はしない**
-- 方針注記: 「アプリの更新は行わない方針です。新しいバージョンの利用には端末の完全フォーマット後の再インストールが必要です。」
-- バージョン(`__APP_VERSION__`)/ ビルド(`env.buildSha` 先頭 7 桁 mono)
-- 保存されている鍵の件数 / 保存済みQRの件数
+- PWA installation status (standalone detection: Installed / Viewing in browser)
+- Offline readiness (SW offlineReady: Ready / Preparing) — **make no safety claim**
+- Policy note: "The policy is not to update the app. Using a new version requires reinstallation after the device has been completely formatted."
+- Version (`__APP_VERSION__`) / build (first 7 characters of `env.buildSha`, mono)
+- Number of stored keys / number of saved QRs
 
-## 5. データの消去(destructive ゾーン: 見出しと枠を destructive 色、TriangleAlert)
+## 5. Data deletion (destructive zone: destructive-colored heading and border, TriangleAlert)
 
-| 操作 | 確認強度 |
+The exact-match phrase below is glossed as "delete all," an English translation of the historical Japanese phrase. The historical input token was Japanese, not this English gloss.
+
+| Action | Confirmation strength |
 |---|---|
-| すべての保存QRを消去 | 通常 AlertDialog |
-| すべての鍵を消去 | **最強: 「全削除」完全一致入力**(spec §28)+「すべての暗号文が復号できなくなります」 |
-| 全ローカルデータ初期化(IndexedDB 削除+localStorage の oc-* 削除) | **最強: 「全削除」完全一致入力** |
+| Clear all saved QRs | Normal AlertDialog |
+| Clear all keys | **Strongest: exact-match entry of the historical phrase meaning "delete all"** (spec §28) + "You will no longer be able to decrypt any ciphertext" |
+| Reset all local data (delete IndexedDB + oc-* entries from localStorage) | **Strongest: exact-match entry of the historical phrase meaning "delete all"** |
 
-確認ダイアログ文言例: 「削除を実行するには「全削除」と入力してください。」入力が一致するまで実行ボタン無効。実行後トースト+件数リセット。
+Example confirmation dialog (English translation of the historical Japanese, with the typed phrase shown as an English gloss): "To delete, enter 'delete all'." Disable the action button until the input matches the historical Japanese phrase exactly. After execution, show a toast + reset the counts.
 
-## 6. セキュリティについて(Collapsible、既定で開く)
+## 6. About security (Collapsible, open by default)
 
-spec §2 の免責リストを全文掲載:
+Include the complete disclaimer list from spec §2:
 
-- このアプリが保証するのは、アプリケーションが意図的に平文や秘密鍵を外部送信しないことまでです。
-- 防御対象外: OS・ブラウザー・ファームウェアの侵害 / キーロガー・画面録画・スクリーンショット / カメラフレームを取得するマルウェア / PWA 初回取得時・再インストール時の供給網侵害 / 端末の物理的な窃取 / ユーザー自身による秘密QRの誤共有 / ブラウザーデータ削除による鍵の消失
-- オフライン表示は現在のネットワーク状態を示す補助情報であり、安全性の証明ではありません。
+- The app's guarantee extends only to the application not intentionally transmitting plaintext or secret keys externally.
+- Outside the scope of protection: compromised OS, browser, or firmware / keyloggers, screen recordings, or screenshots / malware that captures camera frames / supply-chain compromise during the initial PWA download or reinstallation / physical theft of the device / users accidentally sharing secret QRs / key loss through deletion of browser data
+- The offline indicator is supplementary information about the current network state, not proof of safety.
 
-## 機能検出
+## Feature detection
 
-Web Crypto / IndexedDB / カメラ / Service Worker の利用可否一覧(利用不能項目は warning アイコン+「この機能は利用できません: 〜」)。UNSUPPORTED_BROWSER の詳細説明もここへ。
+List availability of Web Crypto / IndexedDB / camera / Service Worker (unavailable items use a warning icon + "This feature is unavailable: …"). Also place the detailed UNSUPPORTED_BROWSER explanation here.


### PR DESCRIPTION
Translate all eight archived design-system documents into English, completing the owner's additional Wave 7 request. Preserve their historical meaning, archive warnings, live-source/spec pointers, MIT attribution, dates, technical values, CSS and original search commands.

Historical Japanese confirmation phrases are explicitly translated glosses. Retired RSA, OCM1, EC-selection and Saved-QR descriptions remain historical records. README now identifies the files as translations, and PROVENANCE's language reference is accurate. Application localization is outside this removal scope.

Validation:

- Independent review of the complete translation found no critical or important issue.
- No Japanese script or CJK punctuation remains in any archive file or filename, including supplementary and halfwidth forms.
- All eight archive warnings and 40 resolving relative links remain; original ASCII code examples, CSS and all three provenance search commands are preserved.
- Final branch is based on merged Wave 5, and all eight document blobs match the reviewed translation.
- `make check`: 91 files / 1,101 tests pass, with no typecheck or lint errors.
- Independent documentation-impact review and the full external-links method pass: all 12 URLs respond, provenance matches the installed archive generator, and the tracked install QR decodes to the app URL. All eight invariants pass. The verified date already equals 2026-09-07, so no registry edit is needed.

Additional Wave 7 following #116. The original Wave 6 requirements were already implemented by #109 and #111 and passed final acceptance during Wave 5.
