### PR TITLE
fix: keep online sessions open during transient probe failures

### DIFF
--- a/.claude/skills/freshness/targets.yaml
+++ b/.claude/skills/freshness/targets.yaml
@@ -456,6 +456,8 @@ units:
     files:
       - docs/spec/qr-protocol-v2.md
       - docs/spec/boot-and-reset-v2.md
+      - src/hooks/use-online-status.ts
+      - src/lib/reachability.ts
       - src/app/boot/boot-controller.ts # acquireRelaySession lifecycle/admission contract
       - src/storage/database.ts # exclusive lease, cancellation, and cooperating sensitive writers
       - tests/ui/boot/relay-session-admission.test.tsx # protected read and pending-read cancellation; integration-owned
@@ -522,11 +524,16 @@ units:
       Visibility refresh releases the session first; display eligibility alone
       cannot admit. Reconcile complete identity/key fingerprint comparison with
       the formatFingerprint contract; wire bytes/golden expectations do not move.
+      Reconcile display-online retention with use-online-status.ts and the raw
+      probe in reachability.ts: a successful probe establishes online; a later
+      failed probe retains it unless the browser explicitly reports offline.
+      Offline events still commit immediately, and boot's offline-publication
+      gate remains authoritative for every offline candidate.
       Update dated statements to current state.
     verify: |
       aube run test:pq
-      aube run test -- tests/ui/boot tests/ui/key-list-page.test.tsx tests/ui/online-relay.test.tsx tests/unit/relay-lease.test.ts
-      aube run test:e2e -- tests/e2e/relay-admission.spec.ts
+      aube run test -- tests/ui/boot tests/ui/boot-app.test.tsx tests/ui/online-status.test.tsx tests/ui/offline-ack.test.tsx tests/ui/key-list-page.test.tsx tests/ui/online-relay.test.tsx tests/unit/relay-lease.test.ts
+      aube run test:e2e -- tests/e2e/relay-admission.spec.ts tests/e2e/online-reachability.spec.ts
 
   - id: size-goldens
     category: crypto

--- a/docs/spec/boot-and-reset-v2.md
+++ b/docs/spec/boot-and-reset-v2.md
@@ -24,10 +24,16 @@ Types and constants are frozen in `src/app/boot/boot-contract.ts`.
   the install server is stopped. The app therefore cannot observe a later
   network reconnection from its own origin, and `navigator.onLine` is the only
   remaining signal. That signal locks; it never wipes. See §2.1.
-- While the display probe sits in a false-negative window, the InstallScreen is
-  not guaranteed to keep blocking. The connectivity gate in §2.1 is what stops
-  that window from opening the Router; the next time the display re-commits
-  online, the symmetric reconciliation re-runs the sentinel check.
+- A successful display probe establishes display-online. Once established, a
+  failed or timed-out display probe retains that state unless
+  `navigator.onLine === false`. Missing, non-boolean, or throwing hints do not
+  establish display-offline. Polling continues, so a temporary request failure
+  leaves the online Home and relay usable without opening the Router.
+- An explicit `offline` event still commits display-offline immediately and
+  aborts any pending display probe. A failed poll with an explicit offline hint
+  also commits display-offline when no event arrives. Cold-start probe failure
+  never establishes online from the hint alone. All offline candidates still
+  pass §2.1; a later display-online recommit re-runs the sentinel check.
 
 ## 2. Boot State Machine (Ahead of the Router)
 
@@ -59,11 +65,11 @@ blocked → (nothing; reload only)
 
 `offline-confirmed` has four possible publication paths — the sentinel-failure
 branch, the post-commit continuation, the display-offline nudge, and an
-`offline` event delivered while probing. All four go through one gate. Gating
-only the sentinel branch would leave the display-offline nudge as a live bypass:
-stopping the install server while the network stays up makes the display probe
-fail, and the nudge would otherwise publish `offline-confirmed` without ever
-re-consulting the sentinel.
+`offline` event delivered while probing. All four go through one gate. Retaining
+confirmed display-online across uncorroborated probe failures prevents a false
+nudge from that path, but an explicit `offline` event can still contradict the
+browser hint. No offline candidate may bypass the hint and deployment checks
+just because the display has committed offline.
 
 The gate publishes `offline-confirmed` only when both hold:
 

--- a/src/hooks/use-online-status.ts
+++ b/src/hooks/use-online-status.ts
@@ -1,11 +1,16 @@
 import { useEffect, useState } from "react"
-import {
-  probeReachability,
-  type AbortableReachabilityProbe,
-} from "@/lib/reachability"
+import { probeReachability, type AbortableReachabilityProbe } from "@/lib/reachability"
 
 const ONLINE_PROBE_INTERVAL_MS = 4000
 const OFFLINE_PROBE_INTERVAL_MS = 15_000
+
+function browserExplicitlyOffline(): boolean {
+  try {
+    return typeof navigator !== "undefined" && navigator.onLine === false
+  } catch {
+    return false
+  }
+}
 
 export function useOnlineStatus(): boolean {
   // navigator.onLine is only a startup hint. Expose `true` after the
@@ -34,12 +39,11 @@ export function useOnlineStatus(): boolean {
       scheduleInterval()
     }
 
-    function finishProbe(
-      probe: AbortableReachabilityProbe,
-      reachable: boolean,
-    ): void {
+    function finishProbe(probe: AbortableReachabilityProbe, reachable: boolean): void {
       if (!active || activeProbe !== probe) return
       activeProbe = null
+      // A failed display probe alone cannot confirm an offline transition.
+      if (!reachable && currentOnline && !browserExplicitlyOffline()) return
       commitStatus(reachable)
     }
 

--- a/tests/e2e/online-reachability.spec.ts
+++ b/tests/e2e/online-reachability.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test, type Request } from "@playwright/test"
+import { loadOnlineGate, mainNavigation } from "./helpers"
+
+function isDisplayProbe(request: Request): boolean {
+  const url = new URL(request.url())
+  return (
+    request.method() === "HEAD" &&
+    url.pathname === "/manifest.webmanifest" &&
+    url.searchParams.has("reach")
+  )
+}
+
+for (const tab of ["Home", "Relay"] as const) {
+  test(`online ${tab} survives repeated display HEAD failures after admission`, async ({
+    context,
+    page,
+  }, testInfo) => {
+    let failDisplayProbes = false
+    let failedProbes = 0
+    const failedRequests: string[] = []
+    page.on("requestfailed", (request) => {
+      if (failDisplayProbes && isDisplayProbe(request)) failedRequests.push(request.url())
+    })
+    await context.route("**/manifest.webmanifest?reach=*", async (route) => {
+      if (failDisplayProbes && isDisplayProbe(route.request())) {
+        failedProbes += 1
+        await route.abort("failed")
+      } else await route.continue()
+    })
+    // Observe protected-store transactions without opening a database ourselves.
+    // Boot and relay admission perform their own legitimate cleanliness reads.
+    await page.addInitScript(() => {
+      const openedStores: string[] = []
+      Object.assign(window, { __reachabilityOpenedStores: openedStores })
+      const transaction = IDBDatabase.prototype.transaction
+      IDBDatabase.prototype.transaction = function (...args) {
+        if (this.name === "qr-crypt") {
+          const names = typeof args[0] === "string" ? [args[0]] : Array.from(args[0])
+          openedStores.push(
+            ...names.filter((name) =>
+              ["keys", "preferences", "pqIdentities", "pqPublicBundles"].includes(name),
+            ),
+          )
+        }
+        return transaction.apply(this, args)
+      }
+    })
+    const now = new Date()
+    await page.clock.install({ time: now })
+    await page.clock.pauseAt(new Date(now.getTime() + 1_000))
+    await loadOnlineGate(page)
+    const navigation = page.getByRole("navigation", { name: "Online navigation" })
+    await expect(navigation).toBeVisible()
+    expect(await page.evaluate(() => navigator.onLine)).toBe(true)
+    const playback = page.getByRole("dialog", { name: "Turn relay text into QR" })
+    if (tab === "Relay") {
+      await page.getByRole("button", { name: "Relay", exact: true }).click()
+      await page.getByRole("button", { name: "Text → QR" }).click()
+      await expect(playback).toBeVisible()
+      await playback.getByLabel("Relay text").fill("relay-session-draft")
+    }
+    const storesAtAdmission = await page.evaluate(
+      () =>
+        (window as Window & { __reachabilityOpenedStores?: string[] })
+          .__reachabilityOpenedStores,
+    )
+    expect(storesAtAdmission).toEqual(expect.any(Array))
+
+    let navigationsAfterAdmission = 0
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame()) navigationsAfterAdmission += 1
+    })
+    failDisplayProbes = true
+    let virtualElapsedMs = 0
+    // Advance until each request has actually failed. Yielding between ticks
+    // lets the browser finish routing instead of timing out queued traffic.
+    for (let poll = 1; poll <= 3; poll += 1) {
+      await expect
+        .poll(
+          async () => {
+            await page.clock.runFor(1_000)
+            virtualElapsedMs += 1_000
+            return failedRequests.length
+          },
+          { intervals: [10] },
+        )
+        .toBeGreaterThanOrEqual(poll)
+    }
+    await testInfo.attach("display-probe-failures", {
+      body: JSON.stringify({ failedProbes, failedRequests, virtualElapsedMs }),
+      contentType: "application/json",
+    })
+    expect(failedProbes).toBeGreaterThanOrEqual(3)
+    expect(virtualElapsedMs).toBeGreaterThanOrEqual(12_000)
+    expect(await page.evaluate(() => navigator.onLine)).toBe(true)
+    expect(navigationsAfterAdmission).toBe(0)
+    const openedStores = await page.evaluate(
+      () =>
+        (window as Window & { __reachabilityOpenedStores?: string[] })
+          .__reachabilityOpenedStores,
+    )
+    expect(openedStores).toEqual(storesAtAdmission)
+    await expect(mainNavigation(page)).toHaveCount(0)
+    await expect
+      .soft(page.getByText("Network connection detected", { exact: true }))
+      .toHaveCount(0)
+    await expect.soft(navigation).toBeVisible()
+    if (tab === "Home") {
+      await expect(
+        page.getByRole("heading", { name: "Install the PWA", exact: true }),
+      ).toBeVisible()
+      await page.getByRole("button", { name: "Relay", exact: true }).click()
+      await page.getByRole("button", { name: "Text → QR" }).click()
+      await expect(playback).toBeVisible()
+    } else {
+      await expect(playback).toBeVisible()
+      await expect(playback.getByLabel("Relay text")).toHaveValue("relay-session-draft")
+    }
+    await playback.getByLabel("Relay text").fill("invalid relay input")
+    await playback.getByRole("button", { name: "Show QR" }).click()
+    await expect(
+      playback.getByText("Relay input rejected", { exact: true }),
+    ).toBeVisible()
+    await playback.getByRole("button", { name: "Close", exact: true }).click()
+    await page.getByRole("button", { name: "Top", exact: true }).click()
+    await expect(
+      page.getByRole("heading", { name: "Install the PWA", exact: true }),
+    ).toBeVisible()
+  })
+}

--- a/tests/e2e/online-reachability.spec.ts
+++ b/tests/e2e/online-reachability.spec.ts
@@ -104,8 +104,8 @@ for (const tab of ["Home", "Relay"] as const) {
     await expect
       .soft(page.getByText("Network connection detected", { exact: true }))
       .toHaveCount(0)
-    await expect.soft(navigation).toBeVisible()
     if (tab === "Home") {
+      await expect.soft(navigation).toBeVisible()
       await expect(
         page.getByRole("heading", { name: "Install the PWA", exact: true }),
       ).toBeVisible()
@@ -122,6 +122,7 @@ for (const tab of ["Home", "Relay"] as const) {
       playback.getByText("Relay input rejected", { exact: true }),
     ).toBeVisible()
     await playback.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(navigation).toBeVisible()
     await page.getByRole("button", { name: "Top", exact: true }).click()
     await expect(
       page.getByRole("heading", { name: "Install the PWA", exact: true }),

--- a/tests/ui/boot-app.test.tsx
+++ b/tests/ui/boot-app.test.tsx
@@ -2,7 +2,7 @@ import "./helpers/module-mocks/feature-detection"
 import "./helpers/module-mocks/pwa"
 import "./helpers/module-mocks/preferences"
 import "./helpers/module-mocks/qr-scanner"
-import { act, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
@@ -10,20 +10,131 @@ import {
   type BootController,
   type BootDecisionSnapshot,
 } from "@/app/boot/boot-controller"
+import { createAppRouter } from "@/app/router"
 import { translate } from "@/i18n/messages"
 import type { BestEffortResetReport } from "@/storage/best-effort-reset"
 import { decision, response } from "../helpers/boot-fixtures"
 import { getPreferences } from "./helpers/fakes/preferences"
-import {
-  expectLanguageField,
-  renderApp,
-  resetUi,
-} from "./helpers/render-app"
+import { expectLanguageField, renderApp, resetUi } from "./helpers/render-app"
 import { setTestOnlineStatus } from "./helpers/network"
 
 describe("App boot gate", () => {
   beforeEach(resetUi)
   afterEach(resetUi)
+
+  it.each(["Home", "Relay"] as const)(
+    "keeps the online %s usable across failed display polls after admission",
+    async (tab) => {
+      // Keep IndexedDB and user interaction callbacks on their native timers.
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] })
+      setTestOnlineStatus(true)
+      const user = userEvent.setup()
+      const openDatabase = vi.spyOn(indexedDB, "open")
+      const routerFactory = vi.fn(createAppRouter)
+      const reloadPage = vi.fn()
+      const quarantine = vi.fn(async () => undefined)
+      const performWipe = vi.fn(async () => ({ ok: true, failedSteps: [] }))
+      let failDisplayProbes = false
+      let failedProbes = 0
+      const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+        const url = new URL(String(input), window.location.href)
+        if (
+          failDisplayProbes &&
+          init?.method === "HEAD" &&
+          url.pathname === "/manifest.webmanifest" &&
+          url.searchParams.has("reach")
+        ) {
+          failedProbes += 1
+          throw new TypeError("display probe unavailable")
+        }
+        return response("QR-CRYPT-REACHABLE")
+      })
+      vi.stubGlobal("fetch", fetchImpl)
+      const controller = createBootController({
+        fetchImpl,
+        readDecision: async () => decision(),
+        quarantine,
+        performWipe,
+      })
+      const endRelaySession = vi.spyOn(controller, "endRelaySession")
+      const rendered = await renderApp("/encrypt", {
+        bootController: controller,
+        reloadPage,
+        routerFactory,
+      })
+      try {
+        const navigation = await screen.findByRole("navigation", {
+          name: "Online navigation",
+        })
+        const home = screen.getByRole("heading", { name: "Install the PWA" })
+        expect(home).toBeVisible()
+        expect(navigation).toBeVisible()
+        expect(controller.getState()).toMatchObject({
+          kind: "network-confirmed",
+          relayEligibility: "eligible",
+        })
+        if (tab === "Relay") {
+          await user.click(screen.getByRole("button", { name: "Relay" }))
+          await user.click(screen.getByRole("button", { name: "Text → QR" }))
+          expect(
+            screen.getByRole("dialog", { name: "Turn relay text into QR" }),
+          ).toBeVisible()
+          fireEvent.change(screen.getByLabelText("Relay text"), {
+            target: { value: "relay-session-draft" },
+          })
+        }
+        const activeView =
+          tab === "Home"
+            ? home
+            : screen.getByRole("dialog", { name: "Turn relay text into QR" })
+
+        failDisplayProbes = true
+        // Include even the offline cadence so BASE reaches the UI assertions
+        // after multiple actual failures, rather than failing on a poll count.
+        for (let poll = 1; poll <= 3; poll += 1) {
+          await act(async () => vi.advanceTimersByTimeAsync(15_000))
+          expect(failedProbes).toBeGreaterThanOrEqual(poll)
+        }
+
+        expect(navigator.onLine).toBe(true)
+        expect
+          .soft(screen.queryByText("Network connection detected"))
+          .not.toBeInTheDocument()
+        expect
+          .soft(screen.queryByRole("navigation", { name: "Main navigation" }))
+          .not.toBeInTheDocument()
+        expect.soft(routerFactory).not.toHaveBeenCalled()
+        expect.soft(getPreferences).not.toHaveBeenCalled()
+        expect
+          .soft(openDatabase.mock.calls.map(([name]) => name))
+          .not.toContain("qr-crypt")
+        expect.soft(quarantine).not.toHaveBeenCalled()
+        expect.soft(performWipe).not.toHaveBeenCalled()
+        expect.soft(reloadPage).not.toHaveBeenCalled()
+        expect.soft(endRelaySession).not.toHaveBeenCalledWith("display-offline")
+        expect.soft(controller.getState()).toMatchObject({
+          kind: "network-confirmed",
+          relayEligibility: "eligible",
+        })
+        expect.soft(navigation).toBeVisible()
+        expect(activeView).toBeVisible()
+        if (tab === "Home") {
+          await user.click(screen.getByRole("button", { name: "Relay" }))
+          expect(screen.getByRole("button", { name: "Text → QR" })).toBeEnabled()
+        } else {
+          expect(screen.getByLabelText("Relay text")).toHaveValue("relay-session-draft")
+          await user.click(screen.getByRole("button", { name: "Close" }))
+          await user.click(screen.getByRole("button", { name: "Top" }))
+          expect(home).toBeVisible()
+        }
+      } finally {
+        rendered.unmount()
+        controller.stop()
+        openDatabase.mockRestore()
+        vi.useRealTimers()
+      }
+    },
+  )
 
   it("respects the injected controller's refusal when opening the relay", async () => {
     setTestOnlineStatus(true)
@@ -53,9 +164,7 @@ describe("App boot gate", () => {
     setTestOnlineStatus(true)
     const controller = createBootController({
       fetchImpl: vi.fn(async () => response("QR-CRYPT-REACHABLE")),
-      performWipe: vi.fn(
-        () => new Promise<BestEffortResetReport>(() => undefined),
-      ),
+      performWipe: vi.fn(() => new Promise<BestEffortResetReport>(() => undefined)),
       readDecision: async () => decision({ sensitiveDataExists: true }),
     })
     await renderApp("/encrypt", { bootController: controller })
@@ -120,16 +229,12 @@ describe("App boot gate", () => {
     })
     await renderApp("/encrypt", { bootController: controller })
 
-    expect(
-      await screen.findByText(translate("en", "gate.heading")),
-    ).toBeVisible()
+    expect(await screen.findByText(translate("en", "gate.heading"))).toBeVisible()
     expect(
       await screen.findByRole("navigation", { name: "Online navigation" }),
     ).toBeVisible()
     await user.click(screen.getByRole("button", { name: "Relay" }))
-    expect(
-      await screen.findByText(translate("en", "relay.card.title")),
-    ).toBeVisible()
+    expect(await screen.findByText(translate("en", "relay.card.title"))).toBeVisible()
     expect(performWipe).not.toHaveBeenCalled()
     controller.stop()
   })
@@ -152,12 +257,8 @@ describe("App boot gate", () => {
       screen.queryByText(translate("en", "relay.card.title")),
     ).not.toBeInTheDocument()
     resolveDecision?.(decision())
-    await user.click(
-      await screen.findByRole("button", { name: "Relay" }),
-    )
-    expect(
-      await screen.findByText(translate("en", "relay.card.title")),
-    ).toBeVisible()
+    await user.click(await screen.findByRole("button", { name: "Relay" }))
+    expect(await screen.findByText(translate("en", "relay.card.title"))).toBeVisible()
     controller.stop()
   })
 

--- a/tests/ui/offline-ack.test.tsx
+++ b/tests/ui/offline-ack.test.tsx
@@ -23,7 +23,7 @@ import { decision, response } from "../helpers/boot-fixtures"
 import { fakeFeatures } from "./helpers/fakes/feature-detection"
 import { useFakeRegisterSW } from "./helpers/fakes/pwa"
 import { getPreferences } from "./helpers/fakes/preferences"
-import { setTestOnlineStatus, stubReachabilityFetch } from "./helpers/network"
+import { setTestOnlineStatus } from "./helpers/network"
 import {
   expectLanguageField,
   memoryLocalStorage,
@@ -36,10 +36,7 @@ const ACK_TITLE = "Confirm before continuing"
 const JA_ACK_TITLE = "続行前の確認"
 const INSTALL_TITLE = translate("en", "gate.heading")
 
-async function renderWipedOnline(
-  initialLanguage: "en" | "ja",
-  reloadPage: () => void,
-) {
+async function renderWipedOnline(initialLanguage: "en" | "ja", reloadPage: () => void) {
   setTestOnlineStatus(true)
   const controller = createBootController({
     fetchImpl: vi.fn(async () => response("QR-CRYPT-REACHABLE")),
@@ -373,7 +370,9 @@ describe("offline acknowledgement shell", () => {
     })
 
     await renderApp("/encrypt", { bootController: controller, reloadPage })
-    await screen.findByText("Local data was reset after an online connection was detected")
+    await screen.findByText(
+      "Local data was reset after an online connection was detected",
+    )
     await flushDisplayProbe()
     act(() => setTestOnlineStatus(false, { emit: true }))
 
@@ -417,9 +416,7 @@ describe("offline acknowledgement shell", () => {
     act(() => setTestOnlineStatus(false, { emit: true }))
 
     expect(await screen.findByText("RESET_FAILED")).toBeInTheDocument()
-    expect(
-      screen.getByText(/Close this tab\./),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Close this tab\./)).toBeInTheDocument()
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
     expect(
       screen.queryByRole("button", {
@@ -459,15 +456,17 @@ describe("offline acknowledgement shell", () => {
     expect(sentinelFetch).toHaveBeenCalledTimes(1)
 
     // Display probes only: no Window online/offline event is emitted.
-    stubReachabilityFetch(false)
+    setTestOnlineStatus(false)
     act(() => document.dispatchEvent(new Event("visibilitychange")))
     expect(await screen.findByRole("heading", { name: ACK_TITLE })).toBeInTheDocument()
     expect(sentinelFetch).toHaveBeenCalledTimes(1)
     expect(performWipe).not.toHaveBeenCalled()
 
-    stubReachabilityFetch(true)
+    setTestOnlineStatus(true)
     act(() => document.dispatchEvent(new Event("visibilitychange")))
-    await screen.findByText("Local data was reset after an online connection was detected")
+    await screen.findByText(
+      "Local data was reset after an online connection was detected",
+    )
     expect(sentinelFetch).toHaveBeenCalledTimes(2)
     expect(consumeMaintenanceToken).toHaveBeenCalledTimes(1)
     expect(performWipe).toHaveBeenCalledTimes(1)
@@ -536,7 +535,7 @@ describe("offline acknowledgement shell", () => {
       )
       const controller = createBootController({
         fetchImpl: vi.fn(async () => response("not-the-sentinel")),
-      readConnectivityHint: () => "offline",
+        readConnectivityHint: () => "offline",
         readDecision: async () => decision(),
       })
 
@@ -603,7 +602,7 @@ describe("offline acknowledgement shell", () => {
     await renderApp("/encrypt", { bootController: controller })
     expect(await screen.findByText(INSTALL_TITLE)).toBeInTheDocument()
 
-    stubReachabilityFetch(false)
+    setTestOnlineStatus(false)
     act(() => document.dispatchEvent(new Event("visibilitychange")))
     expect(await screen.findByRole("heading", { name: ACK_TITLE })).toBeInTheDocument()
     expect(screen.queryByRole("navigation")).not.toBeInTheDocument()

--- a/tests/ui/online-status.test.tsx
+++ b/tests/ui/online-status.test.tsx
@@ -94,24 +94,100 @@ describe("active reachability detection", () => {
     expect(result.current).toBe(true)
   })
 
+  it.each([
+    "online",
+    "indeterminate",
+    "non-boolean",
+    "missing navigator",
+    "throwing",
+  ] as const)(
+    "keeps confirmed online status across failed polls when the hint is %s",
+    async (hint) => {
+      vi.useFakeTimers()
+      setTestOnlineStatus(true)
+      const { result } = renderHook(() => useOnlineStatus())
+      await act(async () => vi.advanceTimersByTimeAsync(0))
+      expect(result.current).toBe(true)
+
+      if (hint === "missing navigator") vi.stubGlobal("navigator", undefined)
+      else
+        Object.defineProperty(navigator, "onLine", {
+          configurable: true,
+          get() {
+            if (hint === "throwing") throw new Error("hint unavailable")
+            if (hint === "non-boolean") return 0
+            return hint === "online" ? true : undefined
+          },
+        })
+      const failedFetch = stubReachabilityFetch(false)
+
+      try {
+        for (let poll = 1; poll <= 3; poll += 1) {
+          await act(async () => vi.advanceTimersByTimeAsync(4_000))
+          expect(failedFetch).toHaveBeenCalledTimes(poll)
+          expect(result.current).toBe(true)
+        }
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    },
+  )
+
+  it("keeps confirmed online status when a later display probe times out", async () => {
+    vi.useFakeTimers()
+    setTestOnlineStatus(true)
+    const { result } = renderHook(() => useOnlineStatus())
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+    expect(result.current).toBe(true)
+
+    let signal: AbortSignal | null | undefined
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>((_input, init) => {
+        signal = init?.signal
+        return new Promise<Response>(() => undefined)
+      }),
+    )
+    await act(async () => vi.advanceTimersByTimeAsync(4_000))
+    expect(signal?.aborted).toBe(false)
+    await act(async () => vi.advanceTimersByTimeAsync(3_000))
+
+    expect(signal?.aborted).toBe(true)
+    expect(navigator.onLine).toBe(true)
+    expect(result.current).toBe(true)
+  })
+
   it("handles the offline event immediately without starting another probe", async () => {
+    vi.useFakeTimers()
     setTestOnlineStatus(true)
     let signal: AbortSignal | null | undefined
-    const fetchMock = vi.fn<typeof fetch>((input, init) => {
-      void input
-      signal = init?.signal
-      return new Promise<Response>(() => undefined)
-    })
+    let finishProbe: ((response: Response) => void) | undefined
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({ status: 204 } as Response)
+      .mockImplementation((_input, init) => {
+        signal = init?.signal
+        return new Promise<Response>((resolve) => {
+          finishProbe = resolve
+        })
+      })
     vi.stubGlobal("fetch", fetchMock)
     const { result } = renderHook(() => useOnlineStatus())
-    await flushProbe()
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+    expect(result.current).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    await act(async () => vi.advanceTimersByTimeAsync(4_000))
+    expect(signal?.aborted).toBe(false)
 
-    act(() => setTestOnlineStatus(false, { emit: true }))
+    // The explicit event is authoritative even if the hint has not caught up.
+    act(() => window.dispatchEvent(new Event("offline")))
 
     expect(result.current).toBe(false)
     expect(signal?.aborted).toBe(true)
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    await act(async () => finishProbe?.({ status: 204 } as Response))
+    expect(result.current).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it("switches from the online interval to the offline interval and back", async () => {
@@ -131,12 +207,15 @@ describe("active reachability detection", () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(3_999))
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    // No event: a failed poll must still observe an explicit offline hint.
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: false })
     await act(async () => vi.advanceTimersByTimeAsync(1))
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(result.current).toBe(false)
 
     await act(async () => vi.advanceTimersByTimeAsync(14_999))
     expect(fetchMock).toHaveBeenCalledTimes(2)
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true })
     await act(async () => vi.advanceTimersByTimeAsync(1))
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(result.current).toBe(true)


### PR DESCRIPTION
An online Home or relay session could enter the terminal “Network connection detected” screen when a periodic display HEAD request failed, even though the browser still reported online. Preserve an already confirmed online state across these failures and keep probing. Explicit offline transitions and the boot, sentinel, wipe and relay admission protections remain enforced.

Add independent regressions for repeated failures, timeouts and unreliable browser hints, plus Home/Relay browser coverage that checks session continuity without protected-store access or reloads. Update the boot specification and its freshness checks.

Validation: independent tests failed on the original code; the integrated change passes `make check` (1,376 unit/UI tests; typecheck and lint) and `make e2e` (42 browser tests, production build included). The 13 existing lint warnings are unchanged.
